### PR TITLE
Decrease min replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Decrease min replicas.
 
 ## [0.2.0] - 2019-09-12
 

--- a/node/service.json
+++ b/node/service.json
@@ -3,6 +3,6 @@
   "memory": 1536,
   "ttl": 30,
   "timeout": 12,
-  "minReplicas": 20,
+  "minReplicas": 10,
   "maxReplicas": 100
 }


### PR DESCRIPTION
With the new multi-cluster structure, current min replicas are too large. Making them smaller will allow for more fine-grained control and more space to release new versions.