### PR TITLE
Add defaultValue to InputValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `defaultValue` to `InputValue`.
 
 ## [0.2.3] - 2019-09-18
 ### Fixed

--- a/graphql/types/ItemMetadata.graphql
+++ b/graphql/types/ItemMetadata.graphql
@@ -35,10 +35,13 @@ type AssemblyOption {
   inputValues: [InputValue]
 }
 
+scalar StringOrBoolean
+
 type InputValue {
   label: String
   maxLength: Int
   type: InputValueType
+  defaultValue: StringOrBoolean
   domain: [String]
 }
 

--- a/node/resolvers/catalog/assemblyOption.test.ts
+++ b/node/resolvers/catalog/assemblyOption.test.ts
@@ -17,6 +17,7 @@ test('should return a TEXT type', async () => {
   expect(result[0].type).toBe('TEXT')
   expect(result[0].maxLength).toBe(20)
   expect(result[0].domain).not.toBeDefined()
+  expect(result[0].defaultValue).toBe('')
 })
 
 test('should return an OPTIONS type', async () => {
@@ -42,12 +43,14 @@ test('should return an OPTIONS type', async () => {
   expect(line1.type).toBe('OPTIONS')
   expect(line1.maxLength).toBe(undefined)
   expect(line1.domain).toHaveLength(1)
-  expect(line1.domain[0]).toBe('One option')
+  expect(line1.domain![0]).toBe('One option')
+  expect(line1.defaultValue).toBe('One option')
 
   expect(line2.label).toBe('Line 2')
   expect(line2.type).toBe('OPTIONS')
   expect(line2.maxLength).toBe(undefined)
   expect(line2.domain).toHaveLength(2)
+  expect(line2.defaultValue).toBe('Two')
 })
 
 test('should return a BOOLEAN type', async () => {
@@ -73,9 +76,11 @@ test('should return a BOOLEAN type', async () => {
   expect(thingA.type).toBe('BOOLEAN')
   expect(thingA.maxLength).toBe(undefined)
   expect(thingA.domain).not.toBeDefined()
+  expect(thingA.defaultValue).toBe(true)
 
   expect(thingB.label).toBe('Use thing B')
   expect(thingB.type).toBe('BOOLEAN')
   expect(thingB.maxLength).toBe(undefined)
   expect(thingB.domain).not.toBeDefined()
+  expect(thingB.defaultValue).toBe(false)
 })

--- a/node/resolvers/catalog/assemblyOption.ts
+++ b/node/resolvers/catalog/assemblyOption.ts
@@ -14,10 +14,17 @@ export const resolvers = {
           ? inputValue.domain
           : undefined
 
+        const defaultValue = type === InputValueType.OPTIONS
+          ? inputValue.domain[0]
+          : type === InputValueType.BOOLEAN
+            ? stringToBoolean(inputValue.domain[0])
+            : ''
+
         acc.push({
           label,
           type,
           maxLength,
+          defaultValue,
           domain,
         })
 
@@ -46,11 +53,18 @@ function defineInputValueType(inputValue: RawInputValue): InputValueType {
   return InputValueType.TEXT
 }
 
+function stringToBoolean(value: string) {
+  return value === 'true'
+    ? true
+    : false
+}
+
 
 interface InputValue {
   label: string
   maxLength?: number
   type: InputValueType
+  defaultValue: string|boolean
   domain?: string[]
 }
 


### PR DESCRIPTION
Resolve defaultValue of the InputValue.

Since we don't pass the domain values of the Boolean type, the UI doesn't know which option was defined first in the API, if it is `true` or `false`.

https://breno--storecomponents.myvtex.com/_v/private/vtex.search-graphql@0.1.0/graphiql/v1?operationName=Product&query=query%20Product(%24slug%3A%20String%2C%20%24identifier%3A%20ProductUniqueIdentifier)%20%7B%0A%20%20product(slug%3A%20%24slug%2C%20identifier%3A%20%24identifier)%20%7B%0A%20%20%20%20itemMetadata%20%7B%0A%20%20%20%20%20%20items%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20assemblyOptions%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%20%20inputValues%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20label%0A%20%20%20%20%20%20%20%20%20%20%20%20maxLength%0A%20%20%20%20%20%20%20%20%20%20%20%20defaultValue%0A%20%20%20%20%20%20%20%20%20%20%20%20type%0A%20%20%20%20%20%20%20%20%20%20%20%20domain%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&variables=%7B%0A%20%20%22slug%22%3A%20%22star-color-top%22%2C%0A%20%20%22identifier%22%3A%20%7B%0A%20%20%20%20%22field%22%3A%20%22id%22%2C%0A%20%20%20%20%22value%22%3A%20%22%22%0A%20%20%7D%0A%7D

![image](https://user-images.githubusercontent.com/284515/65290157-76cd9180-db24-11e9-87a7-4056e16d0fce.png)
