### PR TITLE
in categoryTree, prevent empty answer when categoryId is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevents empty answer in categoryTree if categoryId for product is not found in categoriesIds.
 
 ## [0.6.1] - 2019-10-15
 ### Fixed

--- a/node/resolvers/catalog/product.test.ts
+++ b/node/resolvers/catalog/product.test.ts
@@ -27,8 +27,8 @@ describe('tests related to product resolver', () => {
         mockContext as any
       )
       expect(mockContext.clients.catalog.category).toBeCalledTimes(2)
-      expect(mockContext.clients.catalog.category.mock.calls[0][0]).toBe(10)
-      expect(mockContext.clients.catalog.category.mock.calls[1][0]).toBe(25)
+      expect(mockContext.clients.catalog.category.mock.calls[0][0]).toBe(25)
+      expect(mockContext.clients.catalog.category.mock.calls[1][0]).toBe(10)
     })
 
     test('get correct main category tree for product with more than one tree', async () => {
@@ -53,11 +53,11 @@ describe('tests related to product resolver', () => {
         mockContext as any
       )
       expect(mockContext.clients.catalog.category).toBeCalledTimes(3)
-      expect(mockContext.clients.catalog.category.mock.calls[0][0]).toBe(
+      expect(mockContext.clients.catalog.category.mock.calls[0][0]).toBe(101)
+      expect(mockContext.clients.catalog.category.mock.calls[1][0]).toBe(101003)
+      expect(mockContext.clients.catalog.category.mock.calls[2][0]).toBe(
         101003009
       )
-      expect(mockContext.clients.catalog.category.mock.calls[1][0]).toBe(101003)
-      expect(mockContext.clients.catalog.category.mock.calls[2][0]).toBe(101)
     })
 
     test('ensure that GC account calls the category tree API ', async () => {
@@ -86,6 +86,24 @@ describe('tests related to product resolver', () => {
       expect(mockContext.clients.catalog.categories).toBeCalledTimes(1)
       expect(mockContext.clients.catalog.categories.mock.calls[0][0]).toBe(2) //ensure maximum level was correct
       expect(result!.length).toBe(2)
+    })
+
+    test('if categoryId does not match any id in categoriesIds, find biggest tree', async () => {
+      const catalogProduct = getProduct()
+      catalogProduct.categoryId = '1'
+      catalogProduct.categoriesIds = ['/2064927469/', '/2064927469/630877787/']
+      await resolvers.Product.categoryTree(
+        catalogProduct as any,
+        {},
+        mockContext as any
+      )
+      expect(mockContext.clients.catalog.category).toBeCalledTimes(2)
+      expect(mockContext.clients.catalog.category.mock.calls[0][0]).toBe(
+        2064927469
+      )
+      expect(mockContext.clients.catalog.category.mock.calls[1][0]).toBe(
+        630877787
+      )
     })
   })
 })


### PR DESCRIPTION
#### What problem is this solving?

In GoCommerce products, the categoryId of the product has a bug and is coming as one. So, the resolver would not find anything and would answer an empty array, causing a crash on store. (to be fixed there).

Now, if the product category is not found, returns the biggest tree it finds.

#### How should this be manually tested?

https://fidelis--gc-jjg3536.myvtex.com/produtocypress/p
https://fidelis--storecomponents.myvtex.com/classic-shoes/p

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
