### PR TITLE
use GC API to get product by id as a workaround for now

### DIFF
--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -73,10 +73,13 @@ export class Catalog extends AppClient {
       { metric: 'catalog-productByEan' }
     )
 
-  public productById = (id: string) =>
-    this.get<CatalogProduct[]>(`/pub/products/search?fq=productId:${id}`, {
+  public productById = (id: string) => {
+    const isVtex = this.context.platform === 'vtex'
+    const url = isVtex ? '/pub/products/search?fq=productId:' : '/products/'
+    return this.get<CatalogProduct[]>(`${url}${id}`, {
       metric: 'catalog-productById',
     })
+  }
 
   public productsById = (ids: string[]) =>
     this.get<CatalogProduct[]>(

--- a/node/resolvers/catalog/index.ts
+++ b/node/resolvers/catalog/index.ts
@@ -1,4 +1,3 @@
-import { Functions } from '@gocommerce/utils'
 import { NotFoundError, UserInputError } from '@vtex/api'
 import { all } from 'bluebird'
 import { head, isEmpty, isNil, path, test, pathOr } from 'ramda'
@@ -179,14 +178,11 @@ export const queries = {
 
   product: async (_: any, rawArgs: ProductArgs, ctx: Context) => {
     const {
-      vtex: { account },
       clients: { catalog },
     } = ctx
 
     const args =
-      rawArgs &&
-      isValidProductIdentifier(rawArgs.identifier) &&
-      !Functions.isGoCommerceAcc(account)
+      rawArgs && isValidProductIdentifier(rawArgs.identifier)
         ? rawArgs
         : { identifier: { field: 'slug', value: rawArgs.slug! } }
 


### PR DESCRIPTION
#### What problem is this solving?

There is a api to get GC product by id: `https://api.gocommerce.com/qastore/search/products/3`.

We can use this API in our product query and now we can fetch GC products by id.

#### How should this be manually tested?

https://fidelis--gc-jjg3536.myvtex.com/_v/private/vtex.search-graphql@0.6.4/graphiql/v1?query=%23%20query%20%7B%0A%23%20%20%20product(slug%3A%22produtocypress%22)%20%7B%0A%23%20%20%20%20%20productId%0A%23%20%20%20%20%20productName%0A%23%20%20%20%7D%0A%23%20%7D%0A%0Aquery%20%7B%0A%20%20product(identifier%3A%7Bfield%3A%20id%2C%20value%3A%223%22%7D)%20%7B%0A%20%20%20%20productId%0A%20%20%20%20productName%0A%20%20%7D%0A%7D

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
