### PR TITLE
Encode characters to prevent `script is not allowed` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Encode characters to prevent `Scripts are not allowed` error.
 
 ## [0.7.0] - 2019-10-24
 

--- a/node/clients/catalog.ts
+++ b/node/clients/catalog.ts
@@ -7,7 +7,7 @@ import {
 } from '@vtex/api'
 import { stringify } from 'qs'
 
-import { CatalogCrossSellingTypes } from '../resolvers/catalog/utils'
+import { searchEncodeURI, CatalogCrossSellingTypes } from '../resolvers/catalog/utils'
 
 interface AutocompleteArgs {
   maxRows: number | string
@@ -53,7 +53,7 @@ export class Catalog extends AppClient {
 
   public product = (slug: string) =>
     this.get<CatalogProduct[]>(
-      `/pub/products/search/${slug && slug.toLowerCase()}/p`,
+      `/pub/products/search/${searchEncodeURI(slug && slug.toLowerCase())}/p`,
       { metric: 'catalog-product' }
     )
 
@@ -140,9 +140,9 @@ export class Catalog extends AppClient {
   public facets = (facets: string = '') => {
     const [path, options] = decodeURI(facets).split('?')
     return this.get<CatalogFacets>(
-      `/pub/facets/search/${encodeURI(
+      `/pub/facets/search/${searchEncodeURI(encodeURI(
         `${path.trim()}${options ? '?' + options : ''}`
-      )}`,
+      ))}`,
       { metric: 'catalog-facets' }
     )
   }
@@ -159,8 +159,8 @@ export class Catalog extends AppClient {
 
   public autocomplete = ({ maxRows, searchTerm }: AutocompleteArgs) =>
     this.get<{ itemsReturned: CatalogAutocompleteUnit[] }>(
-      `/buscaautocomplete?maxRows=${maxRows}&productNameContains=${encodeURIComponent(
-        searchTerm
+      `/buscaautocomplete?maxRows=${maxRows}&productNameContains=${searchEncodeURI(
+        encodeURIComponent(searchTerm)
       )}`,
       { metric: 'catalog-autocomplete' }
     )
@@ -207,8 +207,10 @@ export class Catalog extends AppClient {
     map = '',
     hideUnavailableItems = false,
   }: SearchArgs) => {
-    const sanitizedQuery = encodeURIComponent(
-      decodeURIComponent(query || '').trim()
+    const sanitizedQuery = searchEncodeURI(
+      encodeURIComponent(
+        decodeURIComponent(query || '').trim()
+      )
     )
     if (hideUnavailableItems) {
       const segmentData = (this.context as CustomIOContext).segment

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -202,3 +202,29 @@ const getIdFromTree = async (
   }
   return null
 }
+
+export const searchEncodeURI = (str: string) => {
+  return str.replace(/[&%/"'.()]/g, (c: string) => {
+    switch(c) {
+      case '&':
+        return "@-@"
+      case '%':
+        return "@perc@"
+      case '/':
+        return "@slash@"
+      case '"':
+        return "@quo@"
+      case '\'':
+        return "@squo@"
+      case '.':
+        return "@dot@"
+      case '(':
+        return "@lpar@"
+      case ')':
+        return "@rpar@"
+      default: {
+         return c
+      }
+   }
+  })
+}


### PR DESCRIPTION
#### What problem is this solving?
Avoiding `Bad Request! Scripts are not allowed!` error when the passed parameters contain characters `&% / "'. ()`. Because it is using regex, to prevent a very large loss of performance encoding is only done in queries where these characters are common and error numbers are large.

#### How should this be manually tested?
Linking the app into a workspace and testing queries parameters with the cited characters. Example:
Query: `query testeProduct($productIdentifier: ProductUniqueIdentifier) {
  product(identifier: $productIdentifier) {
    link
  }
}`
Variable: `"productIdentifier": {
    "field": "slug",
    "value": "&%/'.()"
  }`