### PR TITLE
Correct encoding to prevent script not allowed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Don't encode characters `/` and `&` in `searchEncodeURI`.
 
 ## [0.7.1] - 2019-10-24
 ### Fixed

--- a/node/resolvers/catalog/utils.ts
+++ b/node/resolvers/catalog/utils.ts
@@ -204,14 +204,10 @@ const getIdFromTree = async (
 }
 
 export const searchEncodeURI = (str: string) => {
-  return str.replace(/[&%/"'.()]/g, (c: string) => {
+  return str.replace(/[%"'.()]/g, (c: string) => {
     switch(c) {
-      case '&':
-        return "@-@"
       case '%':
         return "@perc@"
-      case '/':
-        return "@slash@"
       case '"':
         return "@quo@"
       case '\'':


### PR DESCRIPTION
#### What problem is this solving?
The characters `/` and `&` should not be encoded.