### PR TITLE
make searchMetadata be cache PUBLIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make searchMetadata cache be PUBLIC.
 
 ## [0.9.1] - 2019-11-11
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -72,7 +72,7 @@ type Query {
     Defines terms types: Brand, Category, Department e.g.: c,b
     """
     map: String = ""
-  ): SearchMetadata @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
+  ): SearchMetadata @cacheControl(scope: PUBLIC, maxAge: MEDIUM) @withSegment
 
   """
   Returns products list filtered and ordered


### PR DESCRIPTION
#### What problem is this solving?

This query should not have its result affected by segment, so it can be cache PUBLIC.

#### How should this be manually tested?

https://cachepub--alssports.myvtex.com/climbing/hardware/carabiners?map=c,c,c

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
