### PR TITLE
check if facets args are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Check args provided in facets query to avoid catalog call that returns 405.
 
 ## [0.12.0] - 2019-11-27
 ### Changed

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -52,9 +52,9 @@ interface CategoryByIdResponse {
 }
 
 interface FacetsArgs {
-  query: string
-  map: string
-  hideUnavailableItems: boolean
+  query?: string
+  map?: string
+  hideUnavailableItems?: boolean
 }
 
 interface SearchProduct {


### PR DESCRIPTION
#### What problem is this solving?

Some components are making queries with this args: `{"hideUnavailableItems":true}` and so we hit catalog in this url: `pub/facets/search/?map=&fq=isAvailablePerSalesChannel_1:1&sc=1` which returns a 405.
Now, we check if the query and map are specified and even if they are the same length.

Testing:
navigate and see everything works
https://errors--exitocol.myvtex.com/

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
