### PR TITLE
fix translated searches, change from and to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix translating to wrong language when locale is different than tenant default language.
 
 ## [0.12.1] - 2019-12-04
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -17,7 +17,7 @@
     "querystring": "^0.2.0",
     "ramda": "^0.26.1",
     "slugify": "^1.2.6",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -65,8 +65,9 @@ const translateToStoreDefaultLanguage = async (
   term: string
 ): Promise<string> => {
   const { messagesGraphQL } = clients
-  const { locale: to, tenant } = vtex
-  const { locale: from } = tenant!
+  const { locale: from, tenant } = vtex
+  const { locale: to } = tenant!
+
   return from && from !== to
     ? messagesGraphQL
       .translateV2({
@@ -76,7 +77,7 @@ const translateToStoreDefaultLanguage = async (
             messages: [{ content: term }],
           },
         ],
-        to: to!,
+        to,
       })
       .then(head)
     : term
@@ -343,7 +344,7 @@ export const queries = {
     }
 
     const [productsRaw, searchMetaData] = await all([
-      search.products(args, true),
+      search.products(translatedArgs, true),
       isQueryingMetadata(info)
         ? getSearchMetaData(_, translatedArgs, ctx)
         : emptyTitleTag,

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5731,10 +5731,10 @@ typescript@3.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
   integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.6.3"


### PR DESCRIPTION
#### What problem is this solving?

![image](https://user-images.githubusercontent.com/4925068/70557736-2a618300-1b62-11ea-9126-3d7dcb61b696.png)

Filter navigator for example was not working.

We were translating data from store default language to locale data when it should be the other way around.

If tenant lang is en-US and locale is ja-JP, translate content from ja-JP to en-US before searching catalog.


#### How should this be manually tested?

https://menu--storecomponents.myvtex.com/apparel---accessories/hats/?cultureInfo=ja-JP

See that everything works

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
