### PR TITLE
Add ignoreSpecificationFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `ignoreSpecificationFilters` to the `facets`'s query resolver.
+- `behavior` to the `facets`'s query resolver.
 
 ## [0.12.4] - 2019-12-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `ignoreSpecificationFilters` to the `facets`'s query resolver.
 
 ## [0.12.4] - 2019-12-11
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -323,9 +323,10 @@ facets(
   """
   hideUnavailableItems: Boolean = false
   """
-  If true, ignores SpecificationFilters received on the map and query when returning the facets available.
+  If Static, ignores SpecificationFilters received on the map and query when returning 
+  the facets available, which makes the facets never change.
   """
-  ignoreSpecificationFilters: Boolean = true
+  behavior: String = "Static"
 ): Facets
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -322,6 +322,10 @@ facets(
   If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel.
   """
   hideUnavailableItems: Boolean = false
+  """
+  If true, ignores SpecificationFilters received on the map and query when returning the facets available.
+  """
+  ignoreSpecificationFilters: Boolean = true
 ): Facets
 ```
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -150,6 +150,10 @@ type Query {
     If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel.
     """
     hideUnavailableItems: Boolean = false
+    """
+    If true, ignores SpecificationFilters received on the map and query when returning the facets available.
+    """
+    ignoreSpecificationFilters: Boolean = true
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -151,9 +151,10 @@ type Query {
     """
     hideUnavailableItems: Boolean = false
     """
-    If true, ignores SpecificationFilters received on the map and query when returning the facets available.
+    If Static, ignores SpecificationFilters received on the map and query when returning 
+    the facets available, which makes the facets never change.
     """
-    ignoreSpecificationFilters: Boolean = true
+    behavior: String = "Static"
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -1,6 +1,16 @@
 import { IOContext, NotFoundError, UserInputError } from '@vtex/api'
 import { all } from 'bluebird'
-import { head, isEmpty, isNil, path, pluck, test, pathOr, zip, tail } from 'ramda'
+import {
+  head,
+  isEmpty,
+  isNil,
+  path,
+  pluck,
+  test,
+  pathOr,
+  zip,
+  tail,
+} from 'ramda'
 
 import { resolvers as assemblyOptionResolvers } from './assemblyOption'
 import { resolvers as autocompleteResolvers } from './autocomplete'
@@ -70,16 +80,16 @@ const translateToStoreDefaultLanguage = async (
 
   return from && from !== to
     ? messagesGraphQL
-      .translateV2({
-        indexedByFrom: [
-          {
-            from,
-            messages: [{ content: term }],
-          },
-        ],
-        to,
-      })
-      .then(head)
+        .translateV2({
+          indexedByFrom: [
+            {
+              from,
+              messages: [{ content: term }],
+            },
+          ],
+          to,
+        })
+        .then(head)
     : term
 }
 
@@ -116,7 +126,11 @@ const isQueryingMetadata = (info: any) => {
   )
 }
 
-const filterSpecificationFilters = ({ query, map, ...rest }: Required<FacetsArgs>) => {
+const filterSpecificationFilters = ({
+  query,
+  map,
+  ...rest
+}: Required<FacetsArgs>) => {
   const queryArray = query.split('/')
   const mapArray = map.split(',')
 
@@ -176,15 +190,13 @@ export const queries = {
     }
   },
 
-  facets: async (
-    _: any,
-    args: FacetsArgs,
-    ctx: Context
-  ) => {
+  facets: async (_: any, args: FacetsArgs, ctx: Context) => {
     if (hasFacetsBadArgs(args)) {
       throw new UserInputError('No query or map provided')
     }
-    const { query, map, hideUnavailableItems } = filterSpecificationFilters(args as Required<FacetsArgs>)
+    const { query, map, hideUnavailableItems } = args.ignoreSpecificationFilters
+      ? filterSpecificationFilters(args as Required<FacetsArgs>)
+      : (args as Required<FacetsArgs>)
     const {
       clients: { search },
       clients,

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -194,7 +194,7 @@ export const queries = {
     if (hasFacetsBadArgs(args)) {
       throw new UserInputError('No query or map provided')
     }
-    const { query, map, hideUnavailableItems } = args.ignoreSpecificationFilters
+    const { query, map, hideUnavailableItems } = args.behavior === 'Static'
       ? filterSpecificationFilters(args as Required<FacetsArgs>)
       : (args as Required<FacetsArgs>)
     const {

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -55,6 +55,7 @@ interface FacetsArgs {
   query?: string
   map?: string
   hideUnavailableItems?: boolean
+  ignoreSpecificationFilters?: boolean
 }
 
 interface SearchProduct {

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -55,7 +55,12 @@ interface FacetsArgs {
   query?: string
   map?: string
   hideUnavailableItems?: boolean
-  ignoreSpecificationFilters?: boolean
+  behavior?: FacetsBehavior
+}
+
+enum FacetsBehavior {
+  STATIC = "Static",
+  DYNAMIC = "Dynamic"
 }
 
 interface SearchProduct {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5667,7 +5667,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Add `behavior` to the facets resolver. This will control if the specificationFilters should be used on the catalog query, which dictates if the facets will be static or dynamic.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/Black?map=c,c,specificationFilter_52)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/8443580/71531754-e810a380-28ce-11ea-8343-c626d8a1e288.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes
Works along with:
https://github.com/vtex-apps/store-resources/pull/83
https://github.com/vtex-apps/store/pull/398
https://github.com/vtex-apps/search-result/pull/290
<!-- Put any relevant information that doesn't fit in the other sections here. -->
