### PR TITLE
Add `skuSpecifications` on `Product`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `skuSpecifications` on the `Product` query.
 
 ## [0.13.0] - 2020-01-02
 ### Added

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -37,6 +37,10 @@ type Product {
   """
   items(filter: ItemsFilter): [SKU]
   """
+  List of SKU Specifications
+  """
+  skuSpecifications: [SkuSpecification]
+  """
   Product URL
   """
   link: String
@@ -180,9 +184,17 @@ type SKU {
   attachments: [Attachment] @deprecated(reason: "Use itemMetaData instead")
 }
 
-type skuSpecification {
-  fieldName: String @translatableV2
-  fieldValues: [String] @translatableV2
+type SkuSpecification {
+  field: SKUSpecificationField
+  values: [SKUSpecificationValue]
+}
+
+type SKUSpecificationField {
+  name: String
+}
+
+type SKUSpecificationValue {
+  name: String
 }
 
 type productSpecification {


### PR DESCRIPTION
#### What problem is this solving?

Add new prop `skuSpecifications` on the `Product` query.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p)

Open the console and check that `valuesFromContext -> product. skuSpecifications` exists

#### Notes

Works with a PR in the  store resources
