### PR TITLE
Add handling for empty search results in `gifts` field resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error would be thrown in case `gifts` field tried to fetch information for a product that could not be found by `productSearch` query.
 
 ## [0.19.1] - 2020-03-03
 ### Changed

--- a/node/package.json
+++ b/node/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.13.1",
+    "@vtex/api": "6.17.0",
     "@vtex/test-tools": "^1.2.0",
     "@vtex/tsconfig": "^0.2.0",
     "typemoq": "^2.1.0",

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -46,14 +46,19 @@ export const resolvers = {
     },
     teasers: propOr([], 'Teasers'),
     giftSkuIds: propOr([], 'GiftSkuIds'),
-    gifts: ({ GiftSkuIds }: CommertialOffer, _: any, ctx: Context) => {
+    gifts: async ({ GiftSkuIds }: CommertialOffer, _: any, ctx: Context) => {
       if (GiftSkuIds.length === 0) {
         return []
       }
 
-      const giftProducts = Promise.all(
+      const giftProducts = await Promise.all(
         GiftSkuIds.map(async skuId => {
           const searchResult = await ctx.clients.search.productBySku([skuId])
+
+          if (searchResult.length === 0) {
+            return
+          }
+
           const {
             productName,
             brand,
@@ -62,7 +67,6 @@ export const resolvers = {
             items,
           } = searchResult[0]
           const skuItem = items.find(item => item.itemId === skuId)
-
           const productGiftProperties = {
             productName,
             brand,
@@ -79,8 +83,9 @@ export const resolvers = {
           return productGiftProperties
         })
       )
+      const filteredGiftProducts = giftProducts.filter(Boolean)
 
-      return giftProducts
+      return filteredGiftProducts
     },
     discountHighlights: propOr([], 'DiscountHighLight'),
   },

--- a/node/resolvers/search/offer.ts
+++ b/node/resolvers/search/offer.ts
@@ -23,7 +23,7 @@ export const resolvers = {
 
       /** TODO: Transforms arguments for backwards-compatibility. Should be cleaned up in the future */
       if (criteria === InstallmentsCriteria.MAX_WITH_INTEREST || criteria === InstallmentsCriteria.MAX_WITHOUT_INTEREST){
-        rates = criteria === InstallmentsCriteria.MAX_WITHOUT_INTEREST 
+        rates = criteria === InstallmentsCriteria.MAX_WITHOUT_INTEREST
         criteria = InstallmentsCriteria.MAX
       }
 
@@ -56,7 +56,7 @@ export const resolvers = {
           const searchResult = await ctx.clients.search.productBySku([skuId])
 
           if (searchResult.length === 0) {
-            return
+            return null
           }
 
           const {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1314,10 +1314,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.13.1":
-  version "6.13.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.13.1.tgz#2dc7c00e492d3c474667c5fd09dfeb4d4a79fc61"
-  integrity sha512-ZDlH2+297CPIryIomkjMlzinGu7y77g8fQIkkV0jsikNPYhy/QxDpG3eA7wBsxU40meQG6Lb9Rnu/O5wsl3Thw==
+"@vtex/api@6.17.0":
+  version "6.17.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.17.0.tgz#4498bb1e7a51936fee22d681b5ce47c489cabda0"
+  integrity sha512-CFBkmMbnYGR9RCQoGwTM2mduj/MNXbg/CCzeojAOqepoPE4olNh0mG3X/L25YgJjXrw8d2hyrqrOF2JlE7JhQQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5671,7 +5671,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

This should fix an issue where the `gift` field resolver would try to destructure the properties of a `null` or `undefined` value.

#### How should this be manually tested?

[Workspace](https://productgifts--tbb.myvtex.com/la-vie-est-belle-eau-de-parfum-lancome-perfume-feminino-804902-p/p?__disableSSR)

This page is an example where the field `giftSkuIds` is not null for the product, but the `productSearch` results using the ids from `giftSkuIds` yield in no results. The error caused by trying to access the first result does not happen anymore. 

Notice that the errors in the rendering are due to the product query being updated (there is a new version of `store-resources` linked in the same workspace), which causes the query performed by `render-server` to be different than the linked one.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
