### PR TITLE
Fix encode order for searchEncodeURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Encode order for searchEncodeURI
 
 ## [0.20.3] - 2020-03-18
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-graphql",
-  "version": "0.20.3",
+  "version": "0.20.4-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -162,7 +162,7 @@ export class Search extends AppClient {
   public facets = (facets: string = '') => {
     const [path, options] = decodeURI(facets).split('?')
     return this.get<SearchFacets>(
-      `/pub/facets/search/${this.searchEncodeURI(encodeURI(
+      `/pub/facets/search/${encodeURI(this.searchEncodeURI(
         `${path.trim()}${options ? '?' + options : ''}`
       ))}`,
       { metric: 'search-facets' }
@@ -181,9 +181,9 @@ export class Search extends AppClient {
 
   public autocomplete = ({ maxRows, searchTerm }: AutocompleteArgs) =>
     this.get<{ itemsReturned: SearchAutocompleteUnit[] }>(
-      `/buscaautocomplete?maxRows=${maxRows}&productNameContains=${this.searchEncodeURI(
-        encodeURIComponent(searchTerm)
-      )}`,
+      `/buscaautocomplete?maxRows=${maxRows}&productNameContains=${
+        encodeURIComponent(this.searchEncodeURI(searchTerm))
+      }`,
       { metric: 'search-autocomplete' }
     )
 
@@ -235,10 +235,8 @@ export class Search extends AppClient {
     hideUnavailableItems = false,
     simulationBehavior = SimulationBehavior.DEFAULT,
   }: SearchArgs) => {
-    const sanitizedQuery = this.searchEncodeURI(
-      encodeURIComponent(
-        decodeURIComponent(query || '').trim()
-      )
+    const sanitizedQuery = encodeURIComponent(
+      this.searchEncodeURI(decodeURIComponent(query || '').trim())
     )
     if (hideUnavailableItems) {
       const segmentData = (this.context as CustomIOContext).segment


### PR DESCRIPTION
#### What problem is this solving?
As we were applying `searchEncodeURI` after `encodeURIComponent`, we were wrongly modifying the URL as the example below:

For the URI `/tapetes/tapetes-para-sala-quarto`.

When you apply ```
searchEncodeURI(
    encodeURIComponent(
    decodeURIComponent('/tapetes/tapetes-para-sala-quarto)))```
It produces: `tapetes@perc@2Ftapetes-para-sala-quarto`

When the correct should be only: `tapetes%2Ftapetes-para-sala-quarto`., that is the encoded value for `/tapetes/tapetes-para-sala-quarto`. In this example we should not change `%` for `@perc@` because the `%2F` is only the encoded value for `/`, doesn't have the literal `%`, it will be decoded by catalog api before querying solar for search.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Go to: https://jey--niazi.myvtex.com/tapetes/tapetes-para-sala-quarto
Apply the filter Dimensões many times. You should see the results changing.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
x | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
