### PR TITLE
update schema to follow the new search protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `facets` field to the `facets` query.
+- `fullText`, `productOriginVTEX`, `operator`, `fuzzy` and `searchState` query inputs.
+- `operator`, `fuzzy`, `searchState`, `suggestion`, `banner` and `correction` query outputs.
+- `topSearches`, `suggestionSearches`, `suggestionProducts` placeholders.
+
+### Changed
+- Change from `map` to `selectedFacets`.
 
 ## [0.20.4] - 2020-03-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `facets` field to the `facets` query.
 - `fullText`, `productOriginVTEX`, `operator`, `fuzzy` and `searchState` query inputs.
 - `operator`, `fuzzy`, `searchState`, `suggestion`, `banner` and `correction` query outputs.
-- `topSearches`, `suggestionSearches`, `suggestionProducts` placeholders.
+- `topSearches`, `searchSuggestions`, `productSuggestions` placeholders.
 
 ### Changed
 - Change from `map` to `selectedFacets`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,15 +75,23 @@ query {
 Product Search:
 
 ```
-productSearch(
+  productSearch(
     """
     Terms that is used in search e.g.: eletronics/samsung
     """
     query: String = ""
     """
+    Text inputed by user as the search term
+    """
+    fullText: String = ""
+    """
     Defines terms types: Brand, Category, Department e.g.: c,b
     """
     map: String = ""
+    """
+    Selected facets
+    """
+    selectedFacets: [SelectedFacet]
     """
     Filter by category. {a}/{b} - {a} and {b} are categoryIds
     """
@@ -124,17 +132,40 @@ productSearch(
     If you want faster searches and do not care about most up to date prices and promotions, use skip value.
     """
     simulationBehavior: SimulationBehavior = default
+    """
+    If true, all the products will be solved by VTEX API.
+    """
+    productOriginVtex: Boolean = false
+    """
+    Indicates how the search-engine will deal with the fullText.
+    """
+    operator: Operator
+    """
+    Indicates how the search engine will correct misspeled words.
+    """
+    fuzzy: String
+    """
+    It is similar to fuzzy and operator but is used for scenarios where fuzzy and operator are not enough.
+    """
+    searchState: String
   ): ProductSearch
   ```
 
   ```
   type ProductSearch {
-  products: [Product]
-  recordsFiltered: Int
-  titleTag: String
-  metaTagDescription: String
-  breadcrumb: [SearchBreadcrumb]
-}
+    products: [Product]
+    recordsFiltered: Int
+    titleTag: String
+    metaTagDescription: String
+    breadcrumb: [SearchBreadcrumb]
+    canonical: String
+    suggestion: SearchSuggestions
+    correction: SearchCorrection
+    operator: Operator
+    fuzzy: String
+    searchState: String
+    banners: [SearchBanner]
+  }
 ```
 
   It returns a list of products, the breadcrumb associated for that search, the number of items in total, and SEO related data.
@@ -180,9 +211,17 @@ searchMetadata(
     """
     query: String = ""
     """
+    Text inputed by user as the search term
+    """
+    fullText: String = ""
+    """
     Defines terms types: Brand, Category, Department e.g.: c,b
     """
     map: String = ""
+    """
+    Selected facets
+    """
+    selectedFacets: [SelectedFacet]
   ): SearchMetadata
 ```
 ```
@@ -319,18 +358,38 @@ facets(
   """
   query: String = ""
   """
+  Text inputed by user as the search term
+  """
+  fullText: String = ""
+  """
   Defines terms types: Brand, Category, Department e.g.: c,b
   """
   map: String = ""
+  """
+  Selected facets
+  """
+  selectedFacets: [SelectedFacet]
   """
   If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel.
   """
   hideUnavailableItems: Boolean = false
   """
-  If Static, ignores SpecificationFilters received on the map and query when returning 
+  If Static, ignores SpecificationFilters received on the map and query when returning
   the facets available, which makes the facets never change.
   """
   behavior: String = "Static"
+  """
+  Indicates how the search-engine will deal with the fullText.
+  """
+  operator: Operator
+  """
+  Indicates how the search engine will correct misspeled words.
+  """
+  fuzzy: String
+  """
+  It is similar to fuzzy and operator but is used for scenarios where fuzzy and operator are not enough.
+  """
+  searchState: String
 ): Facets
 ```
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -27,9 +27,17 @@ type Query {
     """
     query: String = ""
     """
+    Text inputted by the user as the search term
+    """
+    fullText: String = ""
+    """
     Defines terms types: Brand, Category, Department e.g.: c,b
     """
     map: String = ""
+    """
+    Selected facets
+    """
+    selectedFacets: [SelectedFacetInput]
     """
     Filter by category. {a}/{b} - {a} and {b} are categoryIds
     """
@@ -70,6 +78,22 @@ type Query {
     If you want faster searches and do not care about most up to date prices and promotions, use skip value.
     """
     simulationBehavior: SimulationBehavior = default
+    """
+    If true, all the products will be solved by VTEX API.
+    """
+    productOriginVtex: Boolean = false
+    """
+    Indicates how the search-engine will deal with the fullText.
+    """
+    operator: Operator
+    """
+    Indicates how the search engine will correct misspeled words.
+    """
+    fuzzy: String
+    """
+    As fuzzy and operator, it controls the searchState, but it is for general purposes
+    """
+    searchState: String
   ): ProductSearch @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   searchMetadata(
@@ -78,9 +102,17 @@ type Query {
     """
     query: String = ""
     """
+    Text inputted by the user as the search term
+    """
+    fullText: String = ""
+    """
     Defines terms types: Brand, Category, Department e.g.: c,b
     """
     map: String = ""
+    """
+    Selected facets
+    """
+    selectedFacets: [SelectedFacetInput]
   ): SearchMetadata @cacheControl(scope: PUBLIC, maxAge: MEDIUM) @withSegment
 
   """
@@ -156,18 +188,38 @@ type Query {
     """
     query: String = ""
     """
+    Text inputted by the user as the search term
+    """
+    fullText: String = ""
+    """
     Defines terms types: Brand, Category, Department e.g.: c,b
     """
     map: String = ""
+    """
+    Selected facets
+    """
+    selectedFacets: [SelectedFacetInput]
     """
     If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel.
     """
     hideUnavailableItems: Boolean = false
     """
-    If Static, ignores SpecificationFilters received on the map and query when returning 
+    If Static, ignores SpecificationFilters received on the map and query when returning
     the facets available, which makes the facets never change.
     """
     behavior: String = "Static"
+    """
+    Indicates how the search-engine will deal with the fullText.
+    """
+    operator: Operator
+    """
+    Indicates how the search engine will correct misspeled words.
+    """
+    fuzzy: String
+    """
+    As fuzzy and operator, it controls the searchState, but it is for general purposes
+    """
+    searchState: String
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """
@@ -185,18 +237,58 @@ type Query {
   ): Suggestions @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """
+  Get top searches from store
+  """
+  topSearches: SearchSuggestions
+    @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
+    @withSegment
+
+  """
+  Get search suggestions
+  """
+  suggestionSearches(
+    """
+    Text inputted by the user as the search term
+    """
+    fullText: String!
+  ): SearchSuggestions
+    @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
+    @withSegment
+
+  """
+  Get product suggestions
+  """
+  suggestionProducts(
+    """
+    Text inputted by the user as the search term
+    """
+    fullText: String!
+    """
+    Selected facet key
+    """
+    facetKey: String
+    """
+    Selected facet value
+    """
+    facetValue: String
+  ): SuggestionProducts
+    @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
+    @withSegment
+
+  """
   Get search urls access stats count
   """
-  searchURLsCount( 
+  searchURLsCount(
     """
     Number of items that is returned
     """
-    limit: Int = 100,
+    limit: Int = 100
 
     """
     Sorting strategy, asc: ascending, desc: descending
     """
-    sort: SORT ): [SearchURLStats] @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    sort: SORT
+  ): [SearchURLStats] @cacheControl(scope: PUBLIC, maxAge: SHORT)
 }
 
 enum SimulationBehavior {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -251,7 +251,7 @@ type Query {
   """
   Get search suggestions
   """
-  suggestionSearches(
+  searchSuggestions(
     """
     Text inputted by the user as the search term
     """
@@ -263,7 +263,7 @@ type Query {
   """
   Get product suggestions
   """
-  suggestionProducts(
+  productSuggestions(
     """
     Text inputted by the user as the search term
     """
@@ -276,7 +276,7 @@ type Query {
     Selected facet value
     """
     facetValue: String
-  ): SuggestionProducts
+  ): ProductSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -79,19 +79,22 @@ type Query {
     """
     simulationBehavior: SimulationBehavior = default
     """
-    If true, all the products will be solved by VTEX API.
+    Each search engine has its own database, but this database might not have all the product information like `clusterHighlights` or `productClusters`.
+    As an alternative, the search engine may use the VTEX API to complete this information by setting this field to true.
     """
     productOriginVtex: Boolean = false
     """
-    Indicates how the search-engine will deal with the fullText.
+    Indicates how the search-engine will deal with the fullText if there is more than one word. Set `and` if the returned products must have all the words in its metadata or `or` otherwise.
     """
     operator: Operator
     """
-    Indicates how the search engine will correct misspeled words.
+    Indicates how the search engine will correct misspelled words by using fuzzy logic.
+    It can be a number representing the max number of misspelled letters, or the string `auto` suggesting that the search-engine should set this value by itself.
     """
     fuzzy: String
     """
-    As fuzzy and operator, it controls the searchState, but it is for general purposes
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
     """
     searchState: String
   ): ProductSearch @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
@@ -209,15 +212,17 @@ type Query {
     """
     behavior: String = "Static"
     """
-    Indicates how the search-engine will deal with the fullText.
+    Indicates how the search-engine will deal with the fullText if there is more than one word. Set `and` if the returned products must have all the words in its metadata or `or` otherwise.
     """
     operator: Operator
     """
-    Indicates how the search engine will correct misspeled words.
+    Indicates how the search engine will correct misspelled words by using fuzzy logic.
+    It can be a number representing the max number of misspelled letters, or the string `auto` suggesting that the search-engine should set this value by itself.
     """
     fuzzy: String
     """
-    As fuzzy and operator, it controls the searchState, but it is for general purposes
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
     """
     searchState: String
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment

--- a/graphql/types/Autocomplete.graphql
+++ b/graphql/types/Autocomplete.graphql
@@ -1,4 +1,6 @@
 type ProductSuggestions {
+    """Number of suggested products"""
     count: Int!
+    """Suggested products"""
     products: [Product]!
 }

--- a/graphql/types/Autocomplete.graphql
+++ b/graphql/types/Autocomplete.graphql
@@ -1,0 +1,4 @@
+type SuggestionProducts {
+    count: Int!
+    products: [Product]!
+}

--- a/graphql/types/Autocomplete.graphql
+++ b/graphql/types/Autocomplete.graphql
@@ -1,4 +1,4 @@
-type SuggestionProducts {
+type ProductSuggestions {
     count: Int!
     products: [Product]!
 }

--- a/graphql/types/Facets.graphql
+++ b/graphql/types/Facets.graphql
@@ -1,6 +1,40 @@
 type QueryArgs {
   map: String
   query: String
+  selectedFacets: [SelectedFacet]
+}
+
+type Range {
+  from: Float
+  to: Float
+}
+
+type FacetValue {
+  id: ID
+  quantity: Int!
+  name: String @translatableV2
+  key: String
+  value: String
+  selected: Boolean
+  children: [FacetValue]
+  range: Range
+  link: String
+  linkEncoded: String
+  href: String
+}
+
+enum FilterType {
+  TEXT
+  NUMBER
+  CATEGORYTREE
+  BRAND
+  PRICERANGE
+}
+
+type Facet {
+  name: String @translatableV2
+  values: [FacetValue]
+  type: FilterType
 }
 
 type Facets {
@@ -11,6 +45,7 @@ type Facets {
   priceRanges: [PriceRangesFacet]
   recordsFiltered: Int
   queryArgs: QueryArgs
+  facets: [Facet]
 }
 
 type DepartmentFacet {

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -5,6 +5,17 @@ type ProductSearch {
   metaTagDescription: String
   breadcrumb: [SearchBreadcrumb]
   canonical: String
+  suggestion: SearchSuggestions
+  correction: SearchCorrection
+  operator: Operator
+  fuzzy: String
+  searchState: String
+  banners: [SearchBanner]
+}
+
+enum Operator {
+  and
+  or
 }
 
 type SearchBreadcrumb {
@@ -15,4 +26,44 @@ type SearchBreadcrumb {
 type SearchMetadata {
   titleTag: String
   metaTagDescription: String
+}
+
+input SelectedFacetInput {
+  key: String
+  value: String
+}
+
+type SelectedFacet  {
+  key: String
+  value: String
+}
+
+type SearchSuggestions {
+  searches: [SearchSuggestion]
+}
+
+type SearchSuggestionAttribute {
+  key: String!
+  value: String!
+  labelValue: String!
+}
+
+type SearchSuggestion {
+  term: String!
+  count: Int!
+  attributes: [SearchSuggestionAttribute]
+}
+
+type SearchCorrection {
+  text: String
+  highlighted: String
+  misspelled: Boolean
+  correction: Boolean
+}
+
+type SearchBanner {
+  id: String
+  name: String
+  area: String
+  html: String
 }

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -247,22 +247,6 @@ export const queries = {
       itemsReturned,
     }
   },
-  topSearches: () => {
-    return {
-      searches: [],
-    }
-  },
-  searchSuggestions: () => {
-    return {
-      searches: [],
-    }
-  },
-  productSuggestions: () => {
-    return {
-      count: 0,
-      products: [],
-    }
-  },
   facets: async (_: any, args: FacetsArgs, ctx: Context) => {
     const { query, hideUnavailableItems } = args
     const {
@@ -531,5 +515,23 @@ export const queries = {
       translatedArgs as SearchArgs
     )
     return getSearchMetaData(_, compatibilityArgs, ctx)
+  },
+  /* All search engines need to implement the topSearches, searchSuggestions, and productSuggestions queries. 
+  VTEX search doesn't support these queries, so it always returns empty results as a placeholder. */
+  topSearches: () => {
+    return {
+      searches: [],
+    }
+  },
+  searchSuggestions: () => {
+    return {
+      searches: [],
+    }
+  },
+  productSuggestions: () => {
+    return {
+      count: 0,
+      products: [],
+    }
   },
 }

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -252,12 +252,12 @@ export const queries = {
       searches: [],
     }
   },
-  suggestionSearches: () => {
+  searchSuggestions: () => {
     return {
       searches: [],
     }
   },
-  suggestionProducts: () => {
+  productSuggestions: () => {
     return {
       count: 0,
       products: [],

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -28,10 +28,18 @@ import { resolvers as recommendationResolvers } from './recommendation'
 import { resolvers as breadcrumbResolvers } from './searchBreadcrumb'
 import { resolvers as skuResolvers } from './sku'
 import { resolvers as productPriceRangeResolvers } from './productPriceRange'
-import { SearchCrossSellingTypes } from './utils'
+import {
+  SearchCrossSellingTypes,
+  getMapAndPriceRangeFromSelectedFacets,
+} from './utils'
 import * as searchStats from '../stats/searchStats'
 import { toCompatibilityArgs, hasFacetsBadArgs } from './newURLs'
-import { PATH_SEPARATOR, SPEC_FILTER, MAP_VALUES_SEP, FACETS_BUCKET } from './constants'
+import {
+  PATH_SEPARATOR,
+  SPEC_FILTER,
+  MAP_VALUES_SEP,
+  FACETS_BUCKET,
+} from './constants'
 import { staleFromVBaseWhileRevalidate } from '../../utils/vbase'
 
 interface ProductIndentifier {
@@ -97,15 +105,23 @@ const translateToStoreDefaultLanguage = async (
   })
 }
 
-const noop = () => { }
+const noop = () => {}
 
 // Does prefetching and warms up cache for up to the 10 first elements of a search, so if user clicks on product page
-const searchFirstElements = (products: SearchProduct[], from: number | null = 0, search: Context['clients']['search']) => {
+const searchFirstElements = (
+  products: SearchProduct[],
+  from: number | null = 0,
+  search: Context['clients']['search']
+) => {
   if (from !== 0 || from == null) {
     // We do not want this for pages other than the first
     return
   }
-  products.slice(0, Math.min(10, products.length)).forEach(product => search.productById(product.productId, false).catch(noop))
+  products
+    .slice(0, Math.min(10, products.length))
+    .forEach(product =>
+      search.productById(product.productId, false).catch(noop)
+    )
 }
 
 export const fieldResolvers = {
@@ -127,15 +143,28 @@ export const fieldResolvers = {
   ...productPriceRangeResolvers,
 }
 
-const getCompatibilityArgs = async <T extends QueryArgs>(ctx: Context, args: T) => {
-  const { clients: {vbase, search} } = ctx
-  const compatArgs = isLegacySearchFormat(args)? args: await toCompatibilityArgs(vbase, search, args)
-  return compatArgs? {...args, ...compatArgs}: args
+const getCompatibilityArgs = async <T extends QueryArgs>(
+  ctx: Context,
+  args: T
+) => {
+  const {
+    clients: { vbase, search },
+  } = ctx
+  const compatArgs = isLegacySearchFormat(args)
+    ? args
+    : await toCompatibilityArgs(vbase, search, args)
+  return compatArgs ? { ...args, ...compatArgs } : args
 }
 
 // Legacy search format is our search with path?map=c,c,specificationFilter
 // Where it has specificationFilters and all segments in path are mapped in `map` querystring
-const isLegacySearchFormat = ({query, map}: {query: string, map?: string}) => {
+const isLegacySearchFormat = ({
+  query,
+  map,
+}: {
+  query: string
+  map?: string
+}) => {
   if (!map) {
     return false
   }
@@ -167,11 +196,11 @@ const filterSpecificationFilters = ({
   const queryArray = query.split('/')
   const mapArray = map.split(',')
 
-  if(queryArray.length < mapArray.length){
+  if (queryArray.length < mapArray.length) {
     return {
       ...rest,
       query,
-      map
+      map,
     }
   }
 
@@ -205,7 +234,10 @@ export const queries = {
     if (!args.searchTerm) {
       throw new UserInputError('No search term provided')
     }
-    const translatedTerm = await translateToStoreDefaultLanguage(ctx, args.searchTerm)
+    const translatedTerm = await translateToStoreDefaultLanguage(
+      ctx,
+      args.searchTerm
+    )
     const { itemsReturned } = await search.autocomplete({
       maxRows: args.maxRows,
       searchTerm: translatedTerm,
@@ -215,39 +247,67 @@ export const queries = {
       itemsReturned,
     }
   },
-
+  topSearches: () => {
+    return {
+      searches: [],
+    }
+  },
+  suggestionSearches: () => {
+    return {
+      searches: [],
+    }
+  },
+  suggestionProducts: () => {
+    return {
+      count: 0,
+      products: [],
+    }
+  },
   facets: async (_: any, args: FacetsArgs, ctx: Context) => {
     const { query, hideUnavailableItems } = args
     const {
       clients: { search, vbase },
     } = ctx
+
+    if (args.selectedFacets) {
+      const [map] = getMapAndPriceRangeFromSelectedFacets(args.selectedFacets)
+      args.map = map
+    }
+
     args.map = args.map && decodeURIComponent(args.map)
-    const translatedQuery = await translateToStoreDefaultLanguage(
-      ctx,
-      query!,
-    )
+    const translatedQuery = await translateToStoreDefaultLanguage(ctx, query!)
     args.query = translatedQuery
     const compatibilityArgs = await getCompatibilityArgs<FacetsArgs>(ctx, args)
 
-    const filteredArgs = args.behavior === 'Static'
-      ? filterSpecificationFilters({...args, query: compatibilityArgs.query, map: compatibilityArgs.map } as Required<FacetsArgs>)
-      : (compatibilityArgs as Required<FacetsArgs>)
+    const filteredArgs =
+      args.behavior === 'Static'
+        ? filterSpecificationFilters({
+            ...args,
+            query: compatibilityArgs.query,
+            map: compatibilityArgs.map,
+          } as Required<FacetsArgs>)
+        : (compatibilityArgs as Required<FacetsArgs>)
 
-    
     if (hasFacetsBadArgs(filteredArgs)) {
       throw new UserInputError('No query or map provided')
     }
 
-    const {query: filteredQuery, map: filteredMap} = filteredArgs
+    const { query: filteredQuery, map: filteredMap } = filteredArgs
 
     const segmentData = ctx.vtex.segment
     const salesChannel = (segmentData && segmentData.channel.toString()) || ''
     const unavailableString = hideUnavailableItems
       ? `&fq=isAvailablePerSalesChannel_${salesChannel}:1`
       : ''
-    
+
     const assembledQuery = `${filteredQuery}?map=${filteredMap}${unavailableString}`
-    const facetsResult = await staleFromVBaseWhileRevalidate(vbase, FACETS_BUCKET, assembledQuery.replace(unavailableString, ''), search.facets, assembledQuery)
+    const facetsResult = await staleFromVBaseWhileRevalidate(
+      vbase,
+      FACETS_BUCKET,
+      assembledQuery.replace(unavailableString, ''),
+      search.facets,
+      assembledQuery
+    )
 
     const result = {
       ...facetsResult,
@@ -363,8 +423,17 @@ export const queries = {
       clients: { search },
     } = ctx
     const queryTerm = args.query
+
+    if (args.selectedFacets) {
+      const [map, priceRange] = getMapAndPriceRangeFromSelectedFacets(
+        args.selectedFacets
+      )
+      args.map = map
+      args.priceRange = priceRange
+    }
+
     args.map = args.map && decodeURIComponent(args.map)
-  
+
     if (queryTerm == null || test(/[?&[\]=]/, queryTerm)) {
       throw new UserInputError(
         `The query term contains invalid characters. query=${queryTerm}`
@@ -383,7 +452,10 @@ export const queries = {
       query,
     }
 
-    const compatibilityArgs = await getCompatibilityArgs<SearchArgs>(ctx, translatedArgs)
+    const compatibilityArgs = await getCompatibilityArgs<SearchArgs>(
+      ctx,
+      translatedArgs
+    )
 
     const [productsRaw, searchMetaData] = await Promise.all([
       search.productsRaw(compatibilityArgs),
@@ -393,14 +465,14 @@ export const queries = {
     ])
 
     searchFirstElements(productsRaw.data, args.from, search)
-    
-     if (productsRaw.status === 200) {
+
+    if (productsRaw.status === 200) {
       searchStats.count(ctx, args)
     }
     return {
       translatedArgs: compatibilityArgs,
       searchMetaData,
-      productsRaw
+      productsRaw,
     }
   },
 
@@ -423,7 +495,7 @@ export const queries = {
       productId,
       searchType
     )
-    
+
     searchFirstElements(products, 0, ctx.clients.search)
     // We add a custom cacheId because these products are not exactly like the other products from search apis.
     // Each product is basically a SKU and you may have two products in response with same ID but each one representing a SKU.
@@ -443,12 +515,21 @@ export const queries = {
         `The query term contains invalid characters. query=${queryTerm}`
       )
     }
+
+    if (args.selectedFacets) {
+      const [map] = getMapAndPriceRangeFromSelectedFacets(args.selectedFacets)
+      args.map = map
+    }
+
     const query = await translateToStoreDefaultLanguage(ctx, args.query || '')
     const translatedArgs = {
       ...args,
       query,
     }
-    const compatibilityArgs = await getCompatibilityArgs<SearchArgs>(ctx, translatedArgs as SearchArgs)
+    const compatibilityArgs = await getCompatibilityArgs<SearchArgs>(
+      ctx,
+      translatedArgs as SearchArgs
+    )
     return getSearchMetaData(_, compatibilityArgs, ctx)
   },
 }

--- a/node/resolvers/search/utils.ts
+++ b/node/resolvers/search/utils.ts
@@ -142,3 +142,19 @@ export const searchEncodeURI = (account: string) => (str: string) => {
   }
   return str
 }
+
+export const getMapAndPriceRangeFromSelectedFacets = (
+  selectedFacets: SelectedFacets[]
+) => {
+  const priceRangeIndex = selectedFacets.findIndex(
+    facet => facet.key === 'priceRange'
+  )
+  const priceRange =
+    priceRangeIndex > -1
+      ? selectedFacets.splice(priceRangeIndex, 1)[0].value
+      : undefined
+
+  const map = selectedFacets.map(facet => facet.key).join(',')
+
+  return [map, priceRange]
+}

--- a/node/typings/Catalog.ts
+++ b/node/typings/Catalog.ts
@@ -1,12 +1,23 @@
+interface Range {
+  from: number;
+  to: number;
+}
+
+interface SelectedFacets {
+  key: string;
+  value: string;
+}
+
 interface QueryArgs {
   query: string
   map?: string
+  selectedFacets?: SelectedFacets[]
 }
 
 interface SearchArgs extends QueryArgs {
   category: string | null
   specificationFilters: string[] | null
-  priceRange: string | null
+  priceRange?: string | null
   collection: string | null
   salesChannel: string | null
   orderBy: string | null

--- a/node/typings/SearchMetadata.ts
+++ b/node/typings/SearchMetadata.ts
@@ -1,6 +1,7 @@
 interface SearchMetadataArgs {
   query?: string | null
   map?: string | null
+  selectedFacets?: SelectedFacets[]
 }
 
 interface SearchMetadata {


### PR DESCRIPTION
#### What problem is this solving?

Currently, VTEX has its own protocol between the search API and the UI components. This protocol forces new search-engines to implement specific rules to communicate with the UI. The [`search-protocol`](https://github.com/vtex/search-protocol) project purposes a generic way to make the UI/API communication.

This PR modify the `search-graphql` resolvers to support the new `search-protocol`. The modifications were:

- Add the `facets` field. VTEX has many fields to represent the facets (categories, priceRange, brand, specification filters...). Search-protocol purposes a single and generic field called `facets`

- New inputs. Some search engines need more information to make a search query. This PR adds `fullText`, `productOriginVTEX`, `operator`, `fuzzy` and `searchState`. You can find the definitions of each input in the [`search-protocol`](https://github.com/vtex/search-protocol) project.

- Add new outputs. New search engines may add new features. This PR adds the following outputs to provide a way to make these features possible: `operator`, `fuzzy`, `searchState`, `suggestion`, `banner` and `correction`. You can find the definitions of each output in the [`search-protocol`](https://github.com/vtex/search-protocol) project.

- Autocomplete placeholders. Soon, we will create a new autocomplete component that will be used by any search-engine. This way, all search-engines need to have queries to support this component. This PR adds placeholders for those queries since VTEX search engine doesn't have support to them yet. They are `topSearches`, `suggestionSearches` and `suggestionProducts`.

- Change `map` to `selectedFacets`. The `search-protocol` doesn't contain references to `map` since it is a specif rule from VTEX. This PR replaces map to `selectedFacets`, a genric version of `map`.

#### How should this be manually tested?
Check the queries made in the Apollo's Chorme extension and see that the new protocol is being used.

![image](https://user-images.githubusercontent.com/40380674/77060018-a9aef000-69b6-11ea-9693-68726b6db858.png)


[Workspace](https://hiago--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
- | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

