### PR TITLE
isLegacySearch only when map and query segments have the same length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- isLegacySearch only when map and query segments have the same length
 
 ## [0.21.0] - 2020-03-24
 ### Added

--- a/node/package.json
+++ b/node/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.17.0",
+    "@vtex/api": "6.22.0",
     "@vtex/tsconfig": "^0.2.0",
     "jest": "^25.1.0",
     "eslint": "^5.15.3",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -36,7 +36,6 @@ import * as searchStats from '../stats/searchStats'
 import { toCompatibilityArgs, hasFacetsBadArgs } from './newURLs'
 import {
   PATH_SEPARATOR,
-  SPEC_FILTER,
   MAP_VALUES_SEP,
   FACETS_BUCKET,
 } from './constants'
@@ -143,7 +142,7 @@ export const fieldResolvers = {
   ...productPriceRangeResolvers,
 }
 
-const getCompatibilityArgs = async <T extends QueryArgs>(
+export const getCompatibilityArgs = async <T extends QueryArgs>(
   ctx: Context,
   args: T
 ) => {
@@ -168,10 +167,7 @@ const isLegacySearchFormat = ({
   if (!map) {
     return false
   }
-  return (
-    map.includes(SPEC_FILTER) ||
-    map.split(MAP_VALUES_SEP).length === query.split(PATH_SEPARATOR).length
-  )
+  return map.split(MAP_VALUES_SEP).length === query.split(PATH_SEPARATOR).length
 }
 
 const isValidProductIdentifier = (identifier: ProductIndentifier | undefined) =>

--- a/node/resolvers/search/newURLs.ts
+++ b/node/resolvers/search/newURLs.ts
@@ -57,7 +57,7 @@ export const mountCompatibilityQuery = async (params: {vbase: VBase, search: Sea
 const normalizeName = (name: string): string => searchSlugify(name)
 
 const fillCategoriesMapSegments = (categories: (CategoryIdNamePair|null)[], map: string): (string|undefined)[] => {
-  const mapSegments = map.split(MAP_SEPARATOR)
+  const mapSegments = map.split(MAP_SEPARATOR).filter(segment=> segment !== CATEGORY_SEGMENT)
   const segmentsFound = []
 
   for( const category of categories){

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -777,10 +777,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.17.0":
-  version "6.17.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.17.0.tgz#4498bb1e7a51936fee22d681b5ce47c489cabda0"
-  integrity sha512-CFBkmMbnYGR9RCQoGwTM2mduj/MNXbg/CCzeojAOqepoPE4olNh0mG3X/L25YgJjXrw8d2hyrqrOF2JlE7JhQQ==
+"@vtex/api@6.22.0":
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.22.0.tgz#a674c9287a61519e03ec24c853bbb0adbdd95d6f"
+  integrity sha512-n2Je79Il4dHc0S9Bjg/4yn5HvCtjQPR84cX+lsectEx+SNlGDEPozqdqNCjCpqUVGHnhg4t7OOjzvDWRY9o+qQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4771,7 +4771,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
There are cases where we cannot discover the specificationFilter because there is no facet for it. This case happens when the specification filter is not under any category. Those filters should be maintained in the query URLs though.

The previous isLegacySearch considered legacy if we had specificationFilters in the URL which is not always the case. This one considers only legacy if we have map and query segments with the same length.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Apply brand filters on the workspaces bellow. Results change

https://jey--txboot.myvtex.com/texasboots/Mens%20Boots?map=specificationFilter_1197
https://jey--boticario.myvtex.com/corpo-e-banho/desodorantes
https://jey--exitocol.myvtex.com/tecnologia/celulares/smartphones
https://jey--alssports.myvtex.com/191?map=productClusterIds

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
x | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
