### PR TITLE
searchmetadata is now responsible for banners suggestion and correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `searchmetadata` is now responsible for `banners` `suggestio` and `correction`
+
 ## [0.21.1] - 2020-03-25
 ### Fixed
 - isLegacySearch only when map and query segments have the same length

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -5,12 +5,9 @@ type ProductSearch {
   metaTagDescription: String
   breadcrumb: [SearchBreadcrumb]
   canonical: String
-  suggestion: SearchSuggestions
-  correction: SearchCorrection
   operator: Operator
   fuzzy: String
   searchState: String
-  banners: [SearchBanner]
 }
 
 enum Operator {
@@ -26,6 +23,9 @@ type SearchBreadcrumb {
 type SearchMetadata {
   titleTag: String
   metaTagDescription: String
+  banners: [SearchBanner]
+  suggestion: SearchSuggestions
+  correction: SearchCorrection
 }
 
 input SelectedFacetInput {
@@ -33,7 +33,7 @@ input SelectedFacetInput {
   value: String
 }
 
-type SelectedFacet  {
+type SelectedFacet {
   key: String
   value: String
 }


### PR DESCRIPTION
#### What problem is this solving?

`searchmetadata` is now responsible for banners suggestion and correction instead of `productSearch`

#### How should this be manually tested?

[Workspace](https://hiago--storecomponents.myvtex.com/shirt?_q=shirt&map=ft)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
