### PR TITLE
Add metrics for toCompatibilityArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- metrics for `toCompatibilityArgs`
 
 ## [0.23.1] - 2020-04-14
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-graphql",
-  "version": "0.23.1",
+  "version": "0.24.0-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -148,10 +148,11 @@ export const getCompatibilityArgs = async <T extends QueryArgs>(
 ) => {
   const {
     clients: { vbase, search },
+    metrics,
   } = ctx
   const compatArgs = isLegacySearchFormat(args)
     ? args
-    : await toCompatibilityArgs(vbase, search, args)
+    : await toCompatibilityArgs(vbase, search, metrics, args)
   return compatArgs ? { ...args, ...compatArgs } : args
 }
 

--- a/node/resolvers/search/newURLs.ts
+++ b/node/resolvers/search/newURLs.ts
@@ -13,13 +13,28 @@ import { PATH_SEPARATOR, MAP_SEPARATOR } from '../stats/constants'
 
 export const hasFacetsBadArgs = ({ query, map }: QueryArgs) => !query || !map
 
-export const toCompatibilityArgs = async (vbase:VBase, search: Search, args: QueryArgs): Promise<QueryArgs|undefined> => {
-  const {query} = args
-  if(!query){
+export const toCompatibilityArgs = async (
+  vbase: VBase,
+  search: Search,
+  metrics: Record<string, [number, number]>,
+  args: QueryArgs
+): Promise<QueryArgs | undefined> => {
+  const toCompatibilityArgsStart = process.hrtime()
+  const { query } = args
+  if (!query) {
     return
   }
-  const { query: compatibilityQuery, map: compatibilityMap } = await staleFromVBaseWhileRevalidate(
-    vbase, SEARCH_URLS_BUCKET, query, mountCompatibilityQuery, {vbase, search, args} )
+  const {
+    query: compatibilityQuery,
+    map: compatibilityMap,
+  } = await staleFromVBaseWhileRevalidate(
+    vbase,
+    SEARCH_URLS_BUCKET,
+    query,
+    mountCompatibilityQuery,
+    { vbase, search, args }
+  )
+  metrics['to-compatibility-args'] = process.hrtime(toCompatibilityArgsStart)
   return { query: compatibilityQuery, map: compatibilityMap }
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Add metrics for `toCompatibilityArgs`

<!--- What is the motivation and context for this change? -->
There is a discussion about moving this method to rewriter. To take this decision it is valuable for us to measure it's latency.

#### How should this be manually tested?
Any search at: https://jey--exitocol.myvtex.com
[Look for this metric on splunk](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20*to-compatibility-args*&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=-1h%40h&latest=now&sid=1586965712.375865_3DDE77BC-1901-4189-B912-ADE751E100F6)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
x | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
