### PR TITLE
add web framework as code owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add web framework team as code owners.
 
 ## [0.24.0] - 2020-04-17
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @vtex-apps/framework-team


### PR DESCRIPTION
We are currently migrating all the resolvers implementation to the vtex-apps/search-resolver and to avoid that anything pass under our radar, we will restrict all PRs of this repository to be approved by a web framework team.