### PR TITLE
Use productName as a fallback to titleTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add web framework team as code owners.
 
+### Fixed
+- Use `productName` as fallback to `titleTag` if there is no `productTitle`.
+
 ## [0.24.0] - 2020-04-17
 ### Added
 - Context to product translatable fields added

--- a/node/resolvers/search/product.ts
+++ b/node/resolvers/search/product.ts
@@ -167,10 +167,14 @@ export const resolvers = {
       context: productId,
     }),
 
-    titleTag: ({ productId, productTitle }: SearchProduct) => formatTranslatableStringV2({
-      content: productTitle,
-      context: productId,
-    }),
+    titleTag: (product: SearchProduct) => {
+      const { productTitle, productId, productName } = product
+
+      return formatTranslatableStringV2({
+        content: productTitle ?? productName ?? '',
+        context: productId,
+      })
+    },
 
     productName: ({ productId, productName }: SearchProduct) => formatTranslatableStringV2({
       content: productName,


### PR DESCRIPTION
#### What problem is this solving?

When the `productTitle` is `null` it was sending the `titleTag` as a string with `null` 

#### How should this be manually tested?

[Workspace](https://titletag--lionspride.myvtex.com/cutter---buck-ladies-victory-long-sleeve-v-neck-shirt-cutte-08701lyn/p)
[You can check the master to see the title of the page](https://lionspride.myvtex.com/cutter---buck-ladies-victory-long-sleeve-v-neck-shirt-cutte-08701lyn/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
