### PR TITLE
Add search-engagement team as the code owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-
 - `@vtex-apps/search-engagement-team` as code owner.
 
 ## [0.25.1] - 2020-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `@vtex-apps/search-engagement-team` as code owner.
+
 ## [0.25.1] - 2020-04-29
 ### Changed
 - Remove the remaining resolvers implementation.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @vtex-apps/framework-team
+*       @vtex-apps/framework-team @vtex-apps/search-engagement-team


### PR DESCRIPTION
#### What problem is this solving?

Now, search-graphql is responsible for providing the queries for all search-engines. This way, any modification in this project may cause breaking changes in other searches.
To track these changes closely, I've added the @vtex-apps/search-engagement-team as the code owner.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

