### PR TITLE
add search-engagement-team as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @vtex-apps/framework-team
+*       @vtex-apps/search-engagement-team


### PR DESCRIPTION
The `VTEX Search Protocol` should be managed by the @vtex-apps/search-engagement-team now that we finally migrated to the new search architecture.