### PR TITLE
Fix SKU Selector on different bindings on PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Translation directive to `SKUSpecificationField` and `SKUSpecificationValue`
 
 ## [0.28.0] - 2020-06-15
-
 ### Added
 - Redirect to `productSearch`.
 - Breadcrumb to `facets`.

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -196,11 +196,11 @@ type SkuSpecification {
 }
 
 type SKUSpecificationField {
-  name: String
+  name: String @translatableV2
 }
 
 type SKUSpecificationValue {
-  name: String
+  name: String @translatableV2
 }
 
 type productSpecification {


### PR DESCRIPTION
#### What problem is this solving?

Previously, when on a PDP with SKUs, if you changed the localization the SKU selectors would break because these fields were not being translated, causing a mismatch in the components.

**Note** This fix needs a PR in the `vtex.search-resolver` to work properly.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/classic-shoes/p?skuId=35)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
