### PR TITLE
add selectedProperties field to the product object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `selectedProperties` field to the `product` object.
+
 ## [0.28.1] - 2020-07-07
 ### Added
 - Translation directive to `SKUSpecificationField` and `SKUSpecificationValue`

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -103,6 +103,16 @@ type Product {
   Product Release Date, for list ordering and product cluster highlight
   """
   releaseDate: String
+
+  """
+  Product properties that will be selected by default. e.g: {key: "Color", value: "Blue"}
+  """
+  selectedProperties: [SelectedProperty]
+}
+
+type SelectedProperty {
+  key: String
+  value: String
 }
 
 enum ItemsFilter {


### PR DESCRIPTION
#### What problem is this solving?

The intelligent search has a feature called split. Basically, instead of showing one product with three possible colors, we show three products, each one with one color.

Before split:
![image](https://user-images.githubusercontent.com/40380674/86956776-06821200-c130-11ea-8534-8824f1c2bd1e.png)
After split:
![image](https://user-images.githubusercontent.com/40380674/86956818-1863b500-c130-11ea-98b5-639ebb4aeaf3.png)


This PR adds a new field called `selectedProperties`. This field has the properties that were selected after the split.

#### How should this be manually tested?

[Workspace](https://hiago--footnotes.myvtex.com/luna%20snake%20flat%20slingback?_q=Luna%20snake%20flat%20slingback&map=ft)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->