### PR TITLE
add productOriginVtex to the productSuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `productOriginVtex`to the `productSuggestions` query.
+- `productOriginVtex` to the `productSuggestions` query.
+- `simulationBehavior` to the `productSuggestions` query.
 
 ## [0.30.0] - 2020-07-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `productOriginVtex`to the `productSuggestions` query.
+
 ## [0.30.0] - 2020-07-21
 ### Added
 - `originalName` to `SpecificationGroup`.

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -312,6 +312,11 @@ type Query {
     Selected facet value
     """
     facetValue: String
+    """"
+    Each search engine has its own database, but this database might not have all the product information like `clusterHighlights` or `productClusters`.
+    As an alternative, the search engine may use the VTEX API to complete this information by setting this field to true.
+    """
+    productOriginVtex: Boolean = false
   ): ProductSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -312,11 +312,15 @@ type Query {
     Selected facet value
     """
     facetValue: String
-    """"
+    """
     Each search engine has its own database, but this database might not have all the product information like `clusterHighlights` or `productClusters`.
     As an alternative, the search engine may use the VTEX API to complete this information by setting this field to true.
     """
     productOriginVtex: Boolean = false
+    """
+    If you want faster searches and do not care about most up to date prices and promotions, use skip value.
+    """
+    simulationBehavior: SimulationBehavior = default
   ): ProductSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment


### PR DESCRIPTION
#### What problem is this solving?
Add the `productOriginVtex`to the `productSuggestions` query.

#### How should this be manually tested?

[Workspace](https://hiago--eriksbikeshop.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->