### PR TITLE
Add 'salesChannel' argument to 'productsByIdentifier' query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `salesChannel` argument to `productsByIdentifier` query.
 
 ## [0.31.0] - 2020-07-31
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -340,6 +340,7 @@ Products By Identifier
 productsByIdentifier(
   field: ProductUniqueIdentifierField!
   values: [ID!]
+  salesChannel: String
 ): [Product]
 ```
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -217,7 +217,7 @@ type Query {
     field: ProductUniqueIdentifierField!
     values: [ID!]
     """
-    Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4
+    Filter by availability at a specific sales channel.
     """
     salesChannel: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -216,6 +216,10 @@ type Query {
   productsByIdentifier(
     field: ProductUniqueIdentifierField!
     values: [ID!]
+    """
+    Filter by availability at a specific sales channel. e.g.: salesChannel:4 if want filter by available products for the sales channel 4
+    """
+    salesChannel: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   """


### PR DESCRIPTION
#### What problem is this solving?

Enables users to query for products in a certain Sales Channel.

#### How should this be manually tested?

Go to this [Workspace](https://victormiranda--storecomponents.myvtex.com/_v/private/vtex.search-graphql@0.32.0-beta.0/graphiql/v1), and perform the query:

```graphql
{
  productsByIdentifier(field: id, values: ["2", "2001"], salesChannel: "4") {
    brand
    productName
  }
}
```

You should get one product as a result. This product is **only** available in this Sales Channel. 

<img width="548" alt="Screen Shot 2020-08-27 at 12 32 54" src="https://user-images.githubusercontent.com/27777263/91463188-758f0380-e861-11ea-874a-ba576a17a987.png">

Try querying for it with `salesChannel: "1"`, and you should receive a `not found` error.

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Related to: https://github.com/vtex-apps/search-resolver/pull/85
