### PR TITLE
add misspelled and operator fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `misspelled` and `operator` to the `productSuggestions` query.
 
 ## [0.34.0] - 2020-09-18
 ### Added

--- a/graphql/types/Autocomplete.graphql
+++ b/graphql/types/Autocomplete.graphql
@@ -1,6 +1,18 @@
 type ProductSuggestions {
-    """Number of suggested products"""
-    count: Int!
-    """Suggested products"""
-    products: [Product]!
+  """
+  Number of suggested products
+  """
+  count: Int!
+  """
+  Suggested products
+  """
+  products: [Product]!
+  """
+  If the term is misspelled or not
+  """
+  misspelled: Boolean
+  """
+  Indicates how the search-engine will deal with the fullText if there is more than one word. Set `and` if the returned products must have all the words in its metadata or `or` otherwise.
+  """
+  operator: Operator
 }


### PR DESCRIPTION
#### What problem is this solving?

`misspelled` and `operator` to the `productSuggestions` query.

#### How should this be manually tested?

[workspace](https://hiago--alssports.myvtex.com/)

By typing in the search-bar the query will be triggered

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
