### PR TITLE
Add changes to make enableFiltersFetchOptimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `quantity` on type `Facet`.
+- Parameters on `values` on `Facet`.
 
 ## [0.35.0] - 2020-09-25
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -395,6 +395,14 @@ facets(
   It is similar to fuzzy and operator but is used for scenarios where fuzzy and operator are not enough.
   """
   searchState: String
+  """
+  Pagination item start
+  """
+  from: Int
+  """
+  Pagination item end
+  """
+  to: Int
 ): Facets
 ```
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -265,6 +265,15 @@ type Query {
     The possible values in this field are defined by each search engine.
     """
     searchState: String
+    """
+    Pagination item start
+    """
+    from: Int
+    """
+    Pagination item end
+    """
+    to: Int
+    
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """

--- a/graphql/types/Facets.graphql
+++ b/graphql/types/Facets.graphql
@@ -33,9 +33,10 @@ enum FilterType {
 
 type Facet {
   name: String @translatableV2
-  values: [FacetValue]
+  values(from: Int, to: Int): [FacetValue]
   type: FilterType
   hidden: Boolean
+  quantity: Int
 }
 
 type Facets {


### PR DESCRIPTION
#### What problem is this solving?

This PR adds some changes necessary to make the store setting `enableFiltersFetchOptimization` work. This setting is responsible for truncating facets after the 10th one  and making it possible to fetch the rest with a refetch.

#### How should this be manually tested?

[Workspace](https://iaronaraujo--storecomponents.myvtex.com/apparel---accessories/clothing/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Go to the workspace and then check on the graphql that in the FacetsV2 query the `from` value is 0 and `to` is 10 
![image](https://user-images.githubusercontent.com/8443580/94735403-14b38900-0341-11eb-8807-9bdffb44aa0d.png)
Then, on the `Color` filter, click on `show 4 more` and notice that the query was re-fetched, updating the results with every facet available!

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
