### PR TITLE
Fix/add original name to properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `originalName` to `Properties` schema.
+
+## [0.36.2-beta] - 2020-12-07
 
 ## [0.36.1] - 2020-12-03
 ### Fixed

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -386,6 +386,7 @@ type SpecificationGroupProperty {
 }
 
 type Property {
+  originalName: String
   name: String @translatableV2
   values: [String] @translatableV2
 }


### PR DESCRIPTION
#### What problem is this solving?

Add missing `originalName` to the `Property` schema

#### How should this be manually tested?

https://kiwi--storecomponents.myvtex.com/_v/private/vtex.search-graphql@0.36.2-beta/graphiql/v1?query=%7B%0A%20%20product(slug%3A%20%22tank-top%22)%20%7B%0A%20%20%20%20productName%0A%20%20%20%20properties%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20originalName%0A%20%20%20%20%7D%0A%20%20%20%20%0A%20%20%20%20specificationGroups%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20originalName%0A%20%20%20%20%20%20specifications%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20originalName%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/101384694-848e4480-3899-11eb-910c-f65019b31097.png)

