### PR TITLE
Disable brand automatic translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Disables automatic translation in brand translatable fields which are related to the brand's name. Now these fileds are user only translatable.
 
 ## [0.37.0] - 2020-12-10
 ### Added

--- a/graphql/types/Brand.graphql
+++ b/graphql/types/Brand.graphql
@@ -18,11 +18,11 @@ type Brand {
   """
    Name of brand
   """
-  name: String @translatableV2
+  name: String @translatableV2(behavior: "USER_ONLY")
   """
    Title used by html tag
   """
-  titleTag: String @translatableV2
+  titleTag: String @translatableV2(behavior: "USER_ONLY")
   """
    Description used by html tag
   """

--- a/graphql/types/Facets.graphql
+++ b/graphql/types/Facets.graphql
@@ -65,7 +65,7 @@ type DepartmentFacet {
 type BrandFacet {
   id: ID!
   quantity: Int!
-  name: String!
+  name: String! @translatableV2(behavior: "USER_ONLY")
   link: String!
   linkEncoded: String!
   map: String

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -2,7 +2,7 @@ type Product {
   """
   Brand of the product
   """
-  brand: String @translatableV2
+  brand: String @translatableV2(behavior: "USER_ONLY")
   """
   Id of the brand of the product
   """

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-graphql",
-  "version": "0.37.0",
+  "version": "0.38.0-beta.0",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "search-graphql",
-  "version": "0.38.0-beta.0",
+  "version": "0.38.0-beta.1",
   "title": "GraphQL API for the VTEX store APIs",
   "description": "GraphQL schema and resolvers for the VTEX API for the catalog and orders.",
   "credentialType": "absolute",


### PR DESCRIPTION
#### What problem is this solving?
This updates the schema so that for brand name related fields which are translatable the @translatable directive receives the USER_ONLY input

#### How should this be manually tested?
It can be tested by linking the search-resolver with this version to the workspace and linking a local version of the messages app in which it is possible to check the messages sent for the translate API when opening this link, https://juaresba--fashion2.myvtex.com/one-pieces, checking if the message with id 2000000 has behavior set as USER_ONLY.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
