### PR TITLE
Add hideUnavailableItems to productSuggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `hideUnavailableItems` to the `productSuggestions` query.
 
 ## [0.38.0] - 2020-12-30
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -326,10 +326,6 @@ type Query {
     """
     facetValue: String
     """
-    If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel
-    """
-    hideUnavailableItems: Boolean = false
-    """
     Each search engine has its own database, but this database might not have all the product information like `clusterHighlights` or `productClusters`.
     As an alternative, the search engine may use the VTEX API to complete this information by setting this field to true.
     """
@@ -338,6 +334,10 @@ type Query {
     If you want faster searches and do not care about most up to date prices and promotions, use skip value.
     """
     simulationBehavior: SimulationBehavior = default
+    """
+    If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel
+    """
+    hideUnavailableItems: Boolean
   ): ProductSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -273,7 +273,7 @@ type Query {
     Pagination item end
     """
     to: Int
-    
+
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """
@@ -325,6 +325,10 @@ type Query {
     Selected facet value
     """
     facetValue: String
+    """
+    If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel
+    """
+    hideUnavailableItems: Boolean = false
     """
     Each search engine has its own database, but this database might not have all the product information like `clusterHighlights` or `productClusters`.
     As an alternative, the search engine may use the VTEX API to complete this information by setting this field to true.


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://hideunavailable--checkoutio.myvtex.com/utmi?_q=utmi&map=ft)
- Type `utmi` in the autocomplete (which is an unavailable product)
- the product should not appear in the autocomplete suggestions

#### Screenshots or example usage


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
