### PR TITLE
Add search result for shortDescription in Product.graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add search result for `shortDescription` in `Product.graphql`
 
 ## [0.40.0] - 2021-02-11
 ### Added

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -33,6 +33,8 @@ type Product {
   """
   description: String @translatableV2
   """
+  shortDescription: String
+  """
   SKU objects of the product
   """
   items(filter: ItemsFilter): [SKU]


### PR DESCRIPTION
#### What problem is this solving?

Our customer requested a type of short description to display the products on the shelf following the unit of sale, eg "Banana 200g". Where "Banana" is the name of the product and "200g" is the short description to describe the amount of sale.

#### How should this be manually tested?

[devyuri](https://devyuri--bighiper.myvtex.com/) on shelf

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
