### PR TITLE
Add initialAttributes to facets query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `initialAttributes` to `facets` query.
+
 ## [0.44.0] - 2021-06-14
 
 ### Added 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -295,6 +295,10 @@ type Query {
     Determines the behavior of the category tree
     """
     categoryTreeBehavior: CategoryTreeBehavior = default
+    """
+    Initial attributes (based on the `initialMap` parameter)
+    """
+    initialAttributes: String
   ): Facets @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
 
   """


### PR DESCRIPTION
#### What problem is this solving?

Add `initialAttributes` to facets query

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--carrefourbr.myvtex.com/admin/graphql-ide)
example:
```
query {
  facets(
    hideUnavailableItems: false,
    behavior: "static",
    initialAttributes: "c,c",
    selectedFacets: [
      {key: "c", value: "eletrodomesticos"},
      {key: "c", value: "geladeira"},
      {key: "b", value: "vonder"}
    ]){
    facets{
      name
      type
      quantity
      values {
        name
        key
        range {
          from
          to
        }
      }
    }
  }
}
```


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
