### PR TITLE
PER-2899 Fix default orderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `orderBy` default value.
+
 ## [0.47.0] - 2021-09-09
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,9 +117,9 @@ Product Search:
     """
     salesChannel: String = ""
     """
-    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC, OrderByScoreDESC
     """
-    orderBy: String = "OrderByPriceDESC"
+    orderBy: String = "OrderByScoreDESC"
     """
     Pagination item start
     """
@@ -287,9 +287,9 @@ Products (list)
     """
     salesChannel: String = ""
     """
-    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC, OrderByScoreDESC
     """
-    orderBy: String = "OrderByPriceDESC"
+    orderBy: String = "OrderByScoreDESC"
     """
     Pagination item start
     """

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -103,9 +103,9 @@ type Query {
     """
     salesChannel: String = ""
     """
-    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC, OrderByScoreDESC
     """
-    orderBy: String = "OrderByPriceDESC"
+    orderBy: String = "OrderByScoreDESC"
     """
     Pagination item start
     """
@@ -201,9 +201,9 @@ type Query {
     """
     salesChannel: String = ""
     """
-    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC
+    Order by a criteria. OrderByPriceDESC/OrderByPriceASC, OrderByTopSaleDESC, OrderByReviewRateDESC, OrderByNameASC/OrderByNameDESC, OrderByReleaseDateDESC, OrderByBestDiscountDESC, OrderByScoreDESC
     """
-    orderBy: String = "OrderByPriceDESC"
+    orderBy: String = "OrderByScoreDESC"
     """
     Pagination item start
     """


### PR DESCRIPTION
#### What problem is this solving?
today the default ordering in our components and in our documentation is by score (relevance) but in the schema, the default ordering was still by price. 
this doesn't affect any store because all stores that use `search-graphql` today already define the ordering that should be used

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--storecomponents.myvtex.com)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
