### PR TITLE
remove duplicated directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove duplicated directives
+
 ## [0.48.1] - 2022-05-16
 
 ### Added

--- a/graphql/directives.graphql
+++ b/graphql/directives.graphql
@@ -1,12 +1,3 @@
 directive @withSegment on FIELD_DEFINITION
 
 directive @toVtexAssets on FIELD_DEFINITION
-
-directive @translatableV2(
-  behavior: String
-) on FIELD_DEFINITION
-
-directive @cacheControl(
-  maxAge: Int
-  scope: String
-) on FIELD_DEFINITION


### PR DESCRIPTION
#### What problem is this solving?

We don't need to delcare @cacheControl or the @translatableV2, because node-vtex-api already does it [here](https://github.com/vtex/node-vtex-api/blob/08ea11d380997f5abf02455487b342caa74b2001/src/service/worker/runtime/graphql/schema/schemaDirectives/CacheControl.ts#L48) and [here](https://github.com/vtex/node-vtex-api/blob/08ea11d380997f5abf02455487b342caa74b2001/src/service/worker/runtime/graphql/schema/schemaDirectives/TranslatableV2.ts#L43)

These duplicated declarations were throwing errors on grapqhl-server. Unfotunally removing this will break the auto-documentation. That's why I removed the pre-commit hook

#### How should this be manually tested?

[Workspace](https://hiago--storecomponents.myvtex.com/)

