### PR TITLE
Add count to productSuggestions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `count` to `productSuggestions` query.
+
 ## [0.48.4] - 2022-05-26
 
 ## [0.48.3] - 2022-05-18

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -392,6 +392,10 @@ type Query {
     If you want to sort by a specification, use the format {specification key}:{asc|desc}. For example: "pricePerUnit:asc" or "size:desc" (this only works on `vtex.search-resolver@1.x`)
     """
     orderBy: String = "OrderByScoreDESC"
+    """
+    Number of product suggestions that should be returned
+    """
+    count: Int
   ): ProductSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment


### PR DESCRIPTION
#### What problem is this solving?

Add count to productSuggestions query, allowing the store to display more than 5 product suggestions.

Currently, this manipulation of how many products to display is done on the client. The query always returns 5 and if the maximum is less than 5, a slice is made. However, if the store wants to display more than 5 suggestions, this doesn't work.

Related to https://github.com/vtex-apps/search-resolver/pull/404

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- [Workspace](https://thalyta--ametllerorigen.myvtex.com/)
- Autocomplete should show 12 product suggestions

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
