### PR TITLE
Adding the Additional Info field to product query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `additionalInfo` to `product` query.
+
 ## [0.53.1] - 2023-06-26
 
 ### Changed

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -326,6 +326,11 @@ type GeneralValueTeaser {
   value: String
 }
 
+type AdditionalInfo {
+  key: String
+  value: String
+}
+
 type TeaserCondition {
   minimumQuantity: Int
   parameters: [TeaserValue]
@@ -348,6 +353,10 @@ type Discount {
   Discount name
   """
   name: String
+  """
+  Additional Info
+  """
+  additionalInfo: [AdditionalInfo]
 }
 
 type DeliverySlaSamples {


### PR DESCRIPTION
#### What problem is this solving?
KitchenAid needed to have the additional Info field (returned from the pricing API to checkout simulation) on the search graphql layer, in order for them to make a component that requires this fields.

#### How should this be manually tested?

[Workspace](https://rfonseca--vtexspain.myvtex.com/admin/graphql-ide)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
Run the following query:
```
query {
  productSearch(fullText: "21") {
    products {
      productName
      items {
        sellers {
          commertialOffer {
            discountHighlights {
              name
              additionalInfo {
		key
                value
              }
            }
          }
        }
      }
    }
  }
}
```

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
