### PR TITLE
Feature: add advertisement field to product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `advertisement` field in `Product` type.
+
 ## [0.56.0] - 2023-09-15
 
 ## [0.55.0] - 2023-08-22

--- a/graphql/types/Advertisement.graphql
+++ b/graphql/types/Advertisement.graphql
@@ -1,0 +1,22 @@
+type Advertisement {
+  """
+  ID of the ad item associated with the sponsored product.
+  """
+  adId: ID
+  """
+  ID of the campaign owner of the ad item.
+  """
+  campaignId: ID
+  """
+  Cost of the goal action. E.g: CPC, cost per click.
+  """
+  actionCost: Float
+  """
+  Ad Request ID.
+  """
+  adRequestId: ID
+  """
+  Ad Response ID.
+  """
+  adResponseId: ID
+}

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -1,4 +1,3 @@
-
 type Product {
   """
   Brand of the product
@@ -113,6 +112,10 @@ type Product {
   Merchandising rule applied to the product
   """
   rule: Rule
+  """
+  If this product is sponsored, ad information will be added here.
+  """
+  advertisement: Advertisement
 }
 
 type SelectedProperty {


### PR DESCRIPTION
#### What problem is this solving?

The `advertisement` field in `Product` will contain some information related to the sponsored product, such as the campaign ID and its cost per click.

This is important because the storefront needs to add this information as data-properties in the HTML so that the Analytics script can observe and collect the metrics.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
