### PR TITLE
Feature: add options field to Advertisement type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `options` field in `Advertisement` type, containing the `hideSponsoredBadge` field.
+
 ## [0.57.0] - 2023-09-20
 
 ### Added

--- a/graphql/types/Advertisement.graphql
+++ b/graphql/types/Advertisement.graphql
@@ -19,4 +19,15 @@ type Advertisement {
   Ad Response ID.
   """
   adResponseId: ID
+  """
+  Additional options for the ad.
+  """
+  options: AdvertisementOptions
+}
+
+type AdvertisementOptions {
+  """
+  Whether to hide the sponsored badge on the ad. Useful for experiments.
+  """
+  hideSponsoredBadge: Boolean
 }


### PR DESCRIPTION
#### What problem is this solving?

Returns the `hideSponsoredBadge` field from the AdServer.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
