### PR TITLE
 Add `anonymousId` query argument for A/B testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Created query parameter `anonymousId` for `sponsoredProducts` used on A/B testing.
+
 ## [0.57.0] - 2023-09-20
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -226,7 +226,7 @@ type Query {
     options: Options
 
     """
-    Identifier for users, logged or not.
+    Identifier for users, logged in or not. Used for A/B tests.
     """
     anonymousId: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -224,6 +224,11 @@ type Query {
     Search options that customize the search result.
     """
     options: Options
+
+    """
+    Identifier for users, logged or not.
+    """
+    anonymousId: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   searchMetadata(


### PR DESCRIPTION
#### What problem is this solving?

We need to integrate A/B testing via Osiris. To do this, the sponsoredProducts query should include the argument `anonymousId`.

#### How should this be manually tested?

[[Workspace](https://orem--biggy.myvtex.com/_v/private/vtex.search-graphql@0.57.0/graphiql/v1)]

This query should work:

```graphql
{
  sponsoredProducts(fullText:"camisa", anonymousId: "the-id") {
    items {name}
  }
} 
```

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
