### PR TITLE
feat: add searchState param to more queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Added `searchState` prop to `searchSuggestions`, `products`, `productRecommendations`, `topSearches` and `autocompleteSearchSuggestions` queries to receive general info from front-end.
 
 ## [0.61.0] - 2024-07-09
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -62,6 +62,11 @@ type Query {
     Search term. It can contain any character.
     """
     fullText: String!
+    """
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
+    """
+    searchState: String
   ): SearchSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment
@@ -325,12 +330,22 @@ type Query {
     Options for advertisement in this search request.
     """
     advertisementOptions: AdvertisementOptions
+    """
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
+    """
+    searchState: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   productRecommendations(
     identifier: ProductUniqueIdentifier
     type: CrossSelingInputEnum
     groupBy: CrossSelingGroupByEnum
+    """
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
+    """
+    searchState: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   productsByIdentifier(
@@ -428,7 +443,13 @@ type Query {
   """
   Get list of the 10 most searched terms
   """
-  topSearches: SearchSuggestions
+  topSearches(
+        """
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
+    """
+    searchState: String
+  ): SearchSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment
 
@@ -440,6 +461,11 @@ type Query {
     Search term. It can contain any character.
     """
     fullText: String!
+    """
+    As fuzzy and operator, it controls the search state, but it is for general purposes. This field allows the search engines to apply features that are not handled by the other fields.
+    The possible values in this field are defined by each search engine.
+    """
+    searchState: String
   ): SearchSuggestions
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
     @withSegment


### PR DESCRIPTION
#### What problem is this solving?

To be able to use the `searchState` param in more queries. This enables us to send user data into the search-resolver app easily from the front-end. Added to the following queries in this PR:
- `searchSuggestions`
- `products`
-  `productRecommendations`
- `topSearches`
- `autocompleteSearchSuggestions`

#### How should this be manually tested?

[Workspace](https://usercookie--worldwidegolf.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️| New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->