### PR TITLE
Add macId and userId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Create query parameter `userId` and `sessionId` for `sponsoredProducts`.
+
 ## [0.66.0] - 2025-03-07
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -244,6 +244,16 @@ type Query {
     Identifier for users, logged in or not. Used for A/B tests.
     """
     anonymousId: String
+
+    """
+    Identifier for user device, used for analytics purposes.
+    """
+    macId: String
+
+    """
+    Identifier for user ID if logged in, used for analytics purposes.
+    """
+    userId: String
   ): [Product] @cacheControl(scope: SEGMENT, maxAge: SHORT) @withSegment
 
   searchMetadata(


### PR DESCRIPTION
#### What problem is this solving?

This PR aims to enable the inclusion of `macId` and `userId` in requests to `search-graphql`. The change is necessary to allow PagueMenos to use `newtail-resolver` for showing sponsored products.

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

