### PR TITLE
feat: add options property to productSearch response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `options` in `ProductSearch` query.
+
 ## [0.67.0] - 2025-03-19
 
 ### Added

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -40,6 +40,14 @@ type ProductSearch {
   Returns the redirect URL set for the given query.
   """
   redirect: String
+  options: ProductSearchOptions
+}
+
+type ProductSearchOptions {
+  """
+  Indicates if delivery promises is enabled.
+  """
+  deliveryPromisesEnabled: Boolean
 }
 
 enum Operator {

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -15,9 +15,11 @@ type ProductSearch {
   String to be used in the `<meta name="description"...` tag.
   """
   metaTagDescription: String
-  breadcrumb: [SearchBreadcrumb] @deprecated(reason: "Use the `breadcrumb` from the `facets` query instead.")
+  breadcrumb: [SearchBreadcrumb]
+    @deprecated(reason: "Use the `breadcrumb` from the `facets` query instead.")
   canonical: String
-  suggestion: SearchSuggestions @deprecated(reason: "Use the `suggestion` query instead.")
+  suggestion: SearchSuggestions
+    @deprecated(reason: "Use the `suggestion` query instead.")
   """
   Object that indicates if the term was misspelled and suggests a possible correction.
   """
@@ -35,11 +37,15 @@ type ProductSearch {
   The possible values in this field are defined by each search engine.
   """
   searchState: String
-  banners: [SearchBanner] @deprecated(reason: "Use the `banners` query instead.")
+  banners: [SearchBanner]
+    @deprecated(reason: "Use the `banners` query instead.")
   """
   Returns the redirect URL set for the given query.
   """
   redirect: String
+  """
+  Options to ProductSearch.
+  """
   options: ProductSearchOptions
 }
 

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -46,14 +46,14 @@ type ProductSearch {
   """
   Options to ProductSearch.
   """
-  options: ProductSearchOptions
+  options: ProductSearchOptions!
 }
 
 type ProductSearchOptions {
   """
   Indicates if delivery promises is enabled.
   """
-  deliveryPromisesEnabled: Boolean
+  deliveryPromisesEnabled: Boolean!
 }
 
 enum Operator {


### PR DESCRIPTION
#### What problem is this solving?

Add options property to `productSearch` response with aim to use the deliveryPromisesEnabled data.

#### How should this be manually tested?

[Workspace](https://dpdemo--mundodocabeleireiro.myvtex.com/_v/private/vtex.search-graphql@0.67.0/graphiql/v1?query=query%20%7B%0A%20%20productSearch(query%3A%22%22)%20%7B%0A%20%20%20%20options%20%7B%0A%20%20%20%20%20%20deliveryPromisesEnabled%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
