### PR TITLE
fix: remove non-nullable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Makes the `options` and `deliveryPromisesEnabled` fields nullable
+
 ## [0.68.0] - 2025-05-12
 
 ### Added

--- a/graphql/types/ProductSearch.graphql
+++ b/graphql/types/ProductSearch.graphql
@@ -46,14 +46,14 @@ type ProductSearch {
   """
   Options to ProductSearch.
   """
-  options: ProductSearchOptions!
+  options: ProductSearchOptions
 }
 
 type ProductSearchOptions {
   """
   Indicates if delivery promises is enabled.
   """
-  deliveryPromisesEnabled: Boolean!
+  deliveryPromisesEnabled: Boolean
 }
 
 enum Operator {


### PR DESCRIPTION
#### What problem is this solving?

Remove non-nullable for ProductSearchOptions and deliveryPromisesEnabled fields. 
After some testing we can see that sometimes deliveryPromisesEnabled can be null.

#### How should this be manually tested?

[Workspace](https://dpdemo--mundodocabeleireiro.myvtex.com/_v/private/vtex.search-graphql@0.68.0/graphiql/v1?query=query%20%7B%0A%20%20productSearch(query%3A%22%22)%20%7B%0A%20%20%20%20options%20%7B%0A%20%20%20%20%20%20deliveryPromisesEnabled%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
