### PR TITLE
feat: add searchId field to ProductSuggestions type

### DIFF
--- a/graphql/types/Autocomplete.graphql
+++ b/graphql/types/Autocomplete.graphql
@@ -15,4 +15,8 @@ type ProductSuggestions {
   Indicates how the search-engine will deal with the fullText if there is more than one word. Set `and` if the returned products must have all the words in its metadata or `or` otherwise.
   """
   operator: Operator
+  """
+  ID used to identify a search query.
+  """
+  searchId: String
 }


### PR DESCRIPTION
This pull request introduces a new field to the `ProductSuggestions` GraphQL type to support search query identification. This enhancement will allow clients to track and reference individual search queries more easily.

GraphQL schema update:

* Added a `searchId` field of type `String` to the `ProductSuggestions` type in `graphql/types/Autocomplete.graphql`, enabling identification of search queries.