### PR TITLE
feat(TIS-388): add specification field to Product type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Created `specification` field of String type in Product type
+
 ## [0.69.3] - 2025-10-02
 
 ### Added

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -117,6 +117,7 @@ type Product {
   """
   advertisement: Advertisement
   deliveryPromisesBadges: [BadgeItem]
+  specification: String
 }
 
 type BadgeItem {


### PR DESCRIPTION
This pull request introduces a new field to the `Product` type in the GraphQL schema to enhance the product data model.

Schema updates:

* Added a `specification` field of type `String` to the `Product` type in `graphql/types/Product.graphql`.

Documentation:

* Documented the addition of the `specification` field in the "Unreleased" section of `CHANGELOG.md`.