### PR TITLE
feat(schema): optional hideUnavailableItems without default false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `Query` arguments `hideUnavailableItems` on `products`, `productSearch`, `facets`, and `productSuggestions`: drop GraphQL default `false` so the argument is optional and unset unless the client passes it.
+
 ## [0.69.4] - 2025-12-03
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -131,7 +131,7 @@ type Query {
     """
     If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel. Will override any given salesChannel arg
     """
-    hideUnavailableItems: Boolean = false
+    hideUnavailableItems: Boolean
     """
     If you want faster searches and do not care about most up to date prices and promotions, use skip value.
     """
@@ -214,7 +214,7 @@ type Query {
     """
     If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel. Will override any given salesChannel arg
     """
-    hideUnavailableItems: Boolean = false
+    hideUnavailableItems: Boolean
     """
     If you want faster searches and do not care about most up to date prices and promotions, use skip value.
     """
@@ -330,7 +330,7 @@ type Query {
     """
     If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel. Will override any given salesChannel arg
     """
-    hideUnavailableItems: Boolean = false
+    hideUnavailableItems: Boolean
     """
     If you want faster searches and do not care about most up to date prices and promotions, use skip value.
     """
@@ -398,7 +398,7 @@ type Query {
     """
     If true, uses isAvailablePerSalesChannel_ parameter on query with segment's sales channel.
     """
-    hideUnavailableItems: Boolean = false
+    hideUnavailableItems: Boolean
     """
     If true, remove hidden facets from the result.
     """


### PR DESCRIPTION
#### What problem is this solving?

With Delivery Promise (DP) on, Intelligent Search does not put unavailable products at the end of the list when hideUnavailableItems is false—they are mixed in with available ones.

To avoid that unless the merchant explicitly sets hideUnavailableItems to false, we change the default when DP is active: if the argument is omitted, the search-resolver treats it as true (instead of behaving like false as before). When DP is off, omitted still behaves like false.

In this PR we stop forcing hideUnavailableItems to false so the value can stay undefined when nothing was configured, and the resolver can apply the rule above.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://dptest--aramismenswear.myvtex.com/)

#### Screenshots or example usage:

Before (unavailable products mixed with available ones when hideUnavailableItems is not set by developer in the time)
<img width="2084" height="774" alt="image" src="https://github.com/user-attachments/assets/46eb9b0a-8d85-459d-b6d8-dfe6db9443a1" />

After:
<img width="2295" height="680" alt="image" src="https://github.com/user-attachments/assets/9253ea3f-6f34-4cc2-964f-fe976d47ae82" />


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
