### PR TITLE
Expose non-structured SKU attributes via SkuNonStructuredAttribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New `SkuNonStructuredAttribute` type and `attributes` field on the `SKU` type to expose non-structured SKU specifications coming from Intelligent Search.
+
 ## [0.70.0] - 2026-05-21
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@ To resolve this query, you need to have an app that implements the schema declar
   - [SelectedFacet](#selectedfacet)
   - [SelectedProperty](#selectedproperty)
   - [Seller](#seller)
+  - [SkuNonStructuredAttribute](#skunonstructuredattribute)
   - [SkuSpecification](#skuspecification)
   - [SpecificationGroup](#specificationgroup)
   - [SpecificationGroupProperty](#specificationgroupproperty)
@@ -2827,6 +2828,11 @@ Discount object
             <td valign="top"><a href="#string">String</a></td>
             <td></td>
         </tr>
+        <tr>
+            <td colspan="2" valign="top"><strong>attributes</strong></td>
+            <td valign="top">[<a href="#skunonstructuredattribute">SkuNonStructuredAttribute</a>]</td>
+            <td><p>List of non-structured SKU specifications for this SKU.</p><p>Populated by Intelligent Search from the SKU <code>attributes</code> array (<code>ProductSkuCatalogAttribute</code>). Represents non-structured SKU specifications created via the Catalog API (<code>/api/catalog/pvt/specification/nonstructured</code>). Distinct from <a href="#skuspecification">SkuSpecification</a>, which represents the structured SKU specifications (field/value pairs used for filters and variations).</p></td>
+        </tr>
     </tbody>
 </table>
 
@@ -3193,6 +3199,45 @@ Object that indicates if the term was misspelled and suggests a possible correct
             <td colspan="2" valign="top"><strong>commertialOffer</strong></td>
             <td valign="top"><a href="#offer">Offer</a></td>
             <td></td>
+        </tr>
+    </tbody>
+</table>
+
+### SkuNonStructuredAttribute
+
+Non-structured SKU specification.
+
+Backed by the Intelligent Search `attributes` field on each SKU (`ProductSkuCatalogAttribute`). Each entry represents a single non-structured SKU specification as registered in the Catalog via `/api/catalog/pvt/specification/nonstructured`. Use [SkuSpecification](#skuspecification) for structured SKU specs (field/value pairs).
+
+<table>
+    <thead>
+        <tr>
+            <th align="left">Field</th>
+            <th align="right">Argument</th>
+            <th align="left">Type</th>
+            <th align="left">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" valign="top"><strong>id</strong></td>
+            <td valign="top"><a href="#id">ID</a></td>
+            <td>Attribute unique identifier (from Catalog).</td>
+        </tr>
+        <tr>
+            <td colspan="2" valign="top"><strong>name</strong></td>
+            <td valign="top"><a href="#string">String</a></td>
+            <td>Attribute name.</td>
+        </tr>
+        <tr>
+            <td colspan="2" valign="top"><strong>value</strong></td>
+            <td valign="top"><a href="#string">String</a></td>
+            <td>Raw attribute value (may contain a JSON-encoded payload).</td>
+        </tr>
+        <tr>
+            <td colspan="2" valign="top"><strong>visible</strong></td>
+            <td valign="top"><a href="#boolean">Boolean</a></td>
+            <td>Whether the attribute is marked as visible in Catalog.</td>
         </tr>
     </tbody>
 </table>

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -214,6 +214,45 @@ type SKU {
   variations: [Property]
   attachments: [Attachment] @deprecated(reason: "Use itemMetaData instead")
   estimatedDateArrival: String
+  """
+  List of non-structured SKU specifications for this SKU.
+
+  Populated by Intelligent Search from the SKU `attributes` array
+  (`ProductSkuCatalogAttribute`). Represents non-structured SKU
+  specifications created via the Catalog API
+  (`/api/catalog/pvt/specification/nonstructured`). Distinct from
+  `SkuSpecification`, which represents the structured SKU
+  specifications (field/value pairs used for filters and variations).
+  """
+  attributes: [SkuNonStructuredAttribute]
+}
+
+"""
+Non-structured SKU specification.
+
+Backed by the Intelligent Search `attributes` field on each SKU
+(`ProductSkuCatalogAttribute`). Each entry represents a single
+non-structured SKU specification as registered in the Catalog via
+`/api/catalog/pvt/specification/nonstructured`. Use `SkuSpecification`
+for structured SKU specs (field/value pairs).
+"""
+type SkuNonStructuredAttribute {
+  """
+  Attribute unique identifier (from Catalog)
+  """
+  id: ID
+  """
+  Attribute name
+  """
+  name: String
+  """
+  Raw attribute value (may contain a JSON-encoded payload)
+  """
+  value: String
+  """
+  Whether the attribute is marked as visible in Catalog
+  """
+  visible: Boolean
 }
 
 type SkuSpecification {

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -224,7 +224,7 @@ type SKU {
   `SkuSpecification`, which represents the structured SKU
   specifications (field/value pairs used for filters and variations).
   """
-  attributes: [SkuNonStructuredAttribute]
+  attributes: [SkuNonStructuredAttribute!]
 }
 
 """
@@ -240,19 +240,19 @@ type SkuNonStructuredAttribute {
   """
   Attribute unique identifier (from Catalog)
   """
-  id: ID
+  id: ID!
   """
   Attribute name
   """
-  name: String
+  name: String!
   """
   Raw attribute value (may contain a JSON-encoded payload)
   """
-  value: String
+  value: String!
   """
   Whether the attribute is marked as visible in Catalog
   """
-  visible: Boolean
+  visible: Boolean!
 }
 
 type SkuSpecification {


### PR DESCRIPTION
#### What problem is this solving?

Store Framework consumers need access to non-structured SKU specifications that the Catalog API exposes through `/api/catalog/pvt/specification/nonstructured`. Intelligent Search already returns those as an `attributes` array on each SKU (`ProductSkuCatalogAttribute`), but the GraphQL schema did not expose them, so storefronts could not render or use those values.

This PR adds:

- New `SkuNonStructuredAttribute` GraphQL object type with `id`, `name`, `value`, and `visible` fields.
- New `attributes: [SkuNonStructuredAttribute]` field on the `SKU` type.

The type is intentionally named `SkuNonStructuredAttribute` (not `SkuCatalogAttribute`) to make the distinction from the existing `SkuSpecification` type explicit: `SkuSpecification` is the structured spec (field/value pairs used for filters and variations) while `SkuNonStructuredAttribute` mirrors the Catalog's non-structured specification API.

Paired with `vtex.search-resolver` PR `feat: resolve SKU.attributes from Intelligent Search`, which implements the resolver. This PR alone is a no-op for runtime behavior - the field returns `null` until the resolver app is bumped.

#### How should this be manually tested?

[Workspace](https://sagginattributes--kohlerdev.myvtex.com/)

Both apps are linked in `kohlerdev/sagginattributes`. Query the resolver app directly (bypassing storefront federation):

```bash
curl -X POST 'https://app.io.vtex.com/vtex.search-resolver/v1/kohlerdev/sagginattributes/_v/graphql' \
  -H 'content-type: application/json' \
  -H 'x-vtex-locale: en-US' \
  -H "Cookie: VtexIdclientAutCookie=<token>" \
  -d '{"query":"{ productSearch(from:0,to:0){ products { items { itemId attributes { __typename id name value visible } } } } }"}'
```

Returns 12 non-structured attributes per SKU on `kohlerdev`, e.g. `SKUIsProjectPack`, `SKUPackagingMaterialType`, `SKUMaterialGroup4`. Schema introspection confirms `__type(name:"SkuNonStructuredAttribute")` exists and `SKU.attributes` is typed `[SkuNonStructuredAttribute]`.

#### Checklist/Reminders

- [x] Updated `README.md` (added `SkuNonStructuredAttribute` section and `SKU.attributes` row to `docs/README.md`).
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Sample response from the workspace:

```json
{
  "productId": "532511",
  "items": [{
    "itemId": "532512",
    "attributes": [
      { "__typename": "SkuNonStructuredAttribute", "id": "32354", "name": "SKUIsProjectPack",         "value": "No",   "visible": true },
      { "__typename": "SkuNonStructuredAttribute", "id": "32355", "name": "SKUPackagingMaterialType", "value": "SIOC", "visible": true },
      { "__typename": "SkuNonStructuredAttribute", "id": "32356", "name": "SKUMaterialGroup4",        "value": "KSM",  "visible": true }
    ]
  }]
}
```

#### Type of changes

✔️ | Type of Change
---|---
_ | Bug fix
✔️ | New feature
_ | Breaking change
_ | Technical improvements

#### Notes

- Backwards-compatible: existing queries are unaffected; the field is optional and resolves to `null` (then `[]` once the resolver lands) when not selected or when the upstream response omits it.
- Must be released together with the matching `vtex.search-resolver` PR for runtime data to flow.
