### PR TITLE
Add priceToken field to Offer type (Pricing Fallback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `priceToken` field on the `Offer` type to expose the signed price token (Pricing Fallback) from Intelligent Search, so consumers can forward it on add-to-cart.
+
 ## [0.71.0] - 2026-05-22
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -2007,6 +2007,11 @@ Discount object
             <td valign="top">[<a href="#gift">Gift</a>]</td>
             <td>List of gifts associated with the product.</td>
         </tr>
+        <tr>
+            <td colspan="2" valign="top"><strong>priceToken</strong></td>
+            <td valign="top"><a href="#string">String</a></td>
+            <td>Signed price token (Pricing Fallback), present when price signing is enabled for the account.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -347,6 +347,12 @@ type Offer {
   List of gifts associated with the product
   """
   gifts: [Gift]
+  """
+  Signed price token (Pricing Fallback). Present when price signing is
+  enabled for the account; forward it unchanged on add-to-cart so checkout
+  can validate price integrity even during a Pricing system outage.
+  """
+  priceToken: String
 }
 
 type Gift {


### PR DESCRIPTION
## Summary
- Expose Intelligent Search's signed price token (Pricing Fallback) as a new optional `priceToken: String` field on the `Offer` GraphQL type
- Purely additive, non-breaking schema change — no required arguments, no version bump in this PR
- Adds matching documentation to `docs/README.md` and a `CHANGELOG.md` entry under `[Unreleased]`

Jira: [TIS-802](https://vtex-dev.atlassian.net/browse/TIS-802)

## Coordination needed before/around merge
- `vtex-apps/search-resolver` needs a matching `priceToken` resolver on `Offer` (pass-through from `commertialOffer.PriceToken`) — this repo has no resolver code, so that's a separate PR.
- Downstream consumers (`checkout-graphql`, `checkout-resources`/add-to-cart-button, `sku-list` B2B Suite) will need to read and forward this token on add-to-cart.
- Version bump (`vtex release minor stable`) is a separate, human-confirmed release step after this merges.

## Test plan
- [x] `node -e "require('graphql').parse(...)"` confirms `graphql/types/Product.graphql` is still valid SDL
- [x] `npx prettier --check` passes on `graphql/types/Product.graphql` and `CHANGELOG.md`
- [x] `grep` confirms the new field/docs/changelog entries are present and correctly placed
- [ ] Reviewer: confirm `search-resolver` PR is opened/coordinated before this merges

[TIS-802]: https://vtex-dev.atlassian.net/browse/TIS-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ